### PR TITLE
feat: Add Python and Go language helpers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,8 @@ docker|d          → Container ops: ps, logs, shell, inspect
 git|g             → Git workflows
 search|s          → Code search (needs: ripgrep)
 ts|node           → TypeScript/Node.js (needs: jq)
+python|py         → Python development (pip, poetry, pytest)
+go|golang         → Go development (modules, testing, linting)
 multi|m           → Multi-file ops (uses: bat)
 env|e             → Environment checks
 api               → API testing (needs: jq, httpie)

--- a/CLAUDE_TEMPLATE.md
+++ b/CLAUDE_TEMPLATE.md
@@ -26,5 +26,7 @@ You have helper scripts at `~/.claude/scripts/` with these aliases:
 - `chs find-code "pattern"` - Fast code search
 - `chg quick-commit "msg"` - Git operations
 - `ch ctx for-task "description"` - Generate focused context
+- `ch py deps` - Python dependencies and tools
+- `ch go test` - Go testing and development
 
 Run `ch help` for all available commands.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Supercharge your Claude Code experience with lightning-fast commands and intelligent workflows.
 
-**🎯 19 Slash Commands** | **⚡ 15 Shell Tools** | **💰 50-80% Token Savings**
+**🎯 19 Slash Commands** | **⚡ 17 Shell Tools** | **🐍 Python Support** | **🐹 Go Support** | **💰 50-80% Token Savings**
 
 ## 🪶 Ultra-Light Context Footprint
 
@@ -84,10 +84,38 @@ These aliases are primarily for Claude to efficiently execute tasks without load
 | **git** | `g` | Git operations | `ch g quick-commit "fix"` |
 | **docker** | `d` | Container management | `ch d ps` |
 | **typescript** | `ts` | Node.js/TypeScript | `ch ts build` |
+| **python** | `py` | Python development | `ch py test` |
+| **go** | `go` | Go development | `ch go build` |
 | **multi** | `m` | Multi-file operations | `ch m read-many f1 f2` |
 | **context** | `ctx` | Claude context generation | `ch ctx for-task "refactor auth"` |
 | **api** | - | API testing toolkit | `ch api test /endpoint` |
 | **interactive** | `i` | Interactive tools (fzf/gum) | `ch i select-file` |
+
+### 🐍 Python Development
+Full support for Python workflows:
+- `ch py deps` - Show dependencies (pip/poetry/pipenv)
+- `ch py test` - Run tests (pytest/unittest)
+- `ch py lint` - Linting (ruff/flake8/mypy)
+- `ch py format` - Formatting (black/autopep8)
+- `ch py venv` - Virtual environment management
+- `ch py audit` - Security vulnerability scanning
+- `ch py run` - Execute scripts or start Django server
+
+### 🐹 Go Development
+Complete Go development toolkit:
+- `ch go deps` - Module dependency management
+- `ch go test` - Run tests with coverage
+- `ch go lint` - Linting (golangci-lint/go vet)
+- `ch go build` - Build with intelligent defaults
+- `ch go mod tidy` - Module maintenance
+- `ch go audit` - Security scanning (nancy/gosec)
+- `ch go bench` - Run benchmarks
+
+### 📄 Markdown Context Extraction
+Quick documentation analysis:
+- `ch ctx mdout` - Extract all markdown outlines + frontmatter
+- `ch ctx mdfm` - Extract only frontmatter from .md files
+- `ch ctx mdh 2` - Extract headers by level (e.g., all ## headers)
 
 ## 💡 Why Use This?
 

--- a/README.md
+++ b/README.md
@@ -77,45 +77,23 @@ These aliases are primarily for Claude to efficiently execute tasks without load
 - `ch` - **Main helper** - Access any tool with `ch [category] [command]`
 
 ### Command Categories
-| Category | Alias | Purpose | Example |
-|----------|-------|---------|---------|
-| **project** | `p` | Project analysis | `ch p` or `chp` |
-| **search** | `s` | Code searching | `ch s find-code "TODO"` |
-| **git** | `g` | Git operations | `ch g quick-commit "fix"` |
-| **docker** | `d` | Container management | `ch d ps` |
-| **typescript** | `ts` | Node.js/TypeScript | `ch ts build` |
-| **python** | `py` | Python development | `ch py test` |
-| **go** | `go` | Go development | `ch go build` |
-| **multi** | `m` | Multi-file operations | `ch m read-many f1 f2` |
-| **context** | `ctx` | Claude context generation | `ch ctx for-task "refactor auth"` |
-| **api** | - | API testing toolkit | `ch api test /endpoint` |
-| **interactive** | `i` | Interactive tools (fzf/gum) | `ch i select-file` |
 
-### 🐍 Python Development
-Full support for Python workflows:
-- `ch py deps` - Show dependencies (pip/poetry/pipenv)
-- `ch py test` - Run tests (pytest/unittest)
-- `ch py lint` - Linting (ruff/flake8/mypy)
-- `ch py format` - Formatting (black/autopep8)
-- `ch py venv` - Virtual environment management
-- `ch py audit` - Security vulnerability scanning
-- `ch py run` - Execute scripts or start Django server
+| Category | Alias | Key Commands | Purpose |
+|----------|-------|--------------|---------|
+| **project** | `p` | `chp` → full project overview | Instant codebase analysis |
+| **search** | `s` | `find-code`, `find-file`, `search-imports` | Lightning-fast code search |
+| **git** | `g` | `quick-commit`, `pr-ready`, `status` | Streamlined git workflows |
+| **docker** | `d` | `ps`, `logs`, `shell`, `inspect` | Container management |
+| **typescript** | `ts` | `deps`, `build`, `test`, `outdated` | Node.js/TypeScript tools |
+| **python** | `py` | `deps`, `test`, `lint`, `venv`, `audit` | Complete Python toolkit |
+| **go** | `go` | `deps`, `test`, `build`, `mod`, `audit` | Full Go development |
+| **context** | `ctx` | `for-task`, `mdout`, `mdfm`, `mdh` | Smart context generation |
+| **multi** | `m` | `read-many`, `read-pattern` | Batch file operations |
+| **api** | - | `test`, `watch`, `benchmark` | API testing & monitoring |
+| **interactive** | `i` | `select-file`, `select-branch` | Interactive selections |
 
-### 🐹 Go Development
-Complete Go development toolkit:
-- `ch go deps` - Module dependency management
-- `ch go test` - Run tests with coverage
-- `ch go lint` - Linting (golangci-lint/go vet)
-- `ch go build` - Build with intelligent defaults
-- `ch go mod tidy` - Module maintenance
-- `ch go audit` - Security scanning (nancy/gosec)
-- `ch go bench` - Run benchmarks
-
-### 📄 Markdown Context Extraction
-Quick documentation analysis:
-- `ch ctx mdout` - Extract all markdown outlines + frontmatter
-- `ch ctx mdfm` - Extract only frontmatter from .md files
-- `ch ctx mdh 2` - Extract headers by level (e.g., all ## headers)
+> 💡 **Usage:** `ch [category] [command]` or use shortcuts like `chp`, `chs`, `chg`  
+> 📚 **Full docs:** Run `ch [category] help` to see all commands for any category
 
 ## 💡 Why Use This?
 

--- a/scripts/claude-context.sh
+++ b/scripts/claude-context.sh
@@ -124,7 +124,7 @@ case "$1" in
                 
                 # Extract headers
                 echo "Outline:"
-                grep "^#\+" "$file" | sed 's/^#/  #/' || echo "  (no headers found)"
+                grep -E "^#+" "$file" | sed 's/^#/  #/' || echo "  (no headers found)"
                 echo ""
             fi
         done
@@ -151,7 +151,7 @@ case "$1" in
         
         if [ -z "$LEVEL" ]; then
             echo "Showing all headers (use $0 md-headers <level> for specific level)"
-            PATTERN="^#\+"
+            PATTERN="^#+"
         else
             echo "Showing level $LEVEL headers"
             PATTERN="^#{$LEVEL} "
@@ -159,7 +159,7 @@ case "$1" in
         echo ""
         
         find . -name "*.md" -o -name "*.mdx" -not -path "*/node_modules/*" -not -path "*/.git/*" | while read -r file; do
-            headers=$(grep "$PATTERN" "$file" 2>/dev/null)
+            headers=$(grep -E "$PATTERN" "$file" 2>/dev/null)
             if [ -n "$headers" ]; then
                 echo -e "${YELLOW}$file:${NC}"
                 echo "$headers" | sed 's/^/  /'

--- a/scripts/claude-context.sh
+++ b/scripts/claude-context.sh
@@ -104,6 +104,70 @@ case "$1" in
             2>/dev/null
         ;;
     
+    "markdown-outline"|"md-outline"|"mdout")
+        # Extract markdown outlines (headers only)
+        echo -e "${GREEN}=== MARKDOWN OUTLINES ===${NC}"
+        echo ""
+        
+        # Find all markdown files
+        find . -name "*.md" -o -name "*.mdx" -not -path "*/node_modules/*" -not -path "*/.git/*" | while read -r file; do
+            if [ -f "$file" ]; then
+                # Extract headers and frontmatter
+                echo -e "${YELLOW}=== $file ===${NC}"
+                
+                # Check for frontmatter
+                if head -1 "$file" | grep -q "^---"; then
+                    echo "Frontmatter:"
+                    awk '/^---$/{if(++count==2)exit}1' "$file" | tail -n +2 | head -n -1 | sed 's/^/  /'
+                    echo ""
+                fi
+                
+                # Extract headers
+                echo "Outline:"
+                grep "^#\+" "$file" | sed 's/^#/  #/' || echo "  (no headers found)"
+                echo ""
+            fi
+        done
+        ;;
+    
+    "markdown-frontmatter"|"md-fm"|"mdfm")
+        # Extract only frontmatter from markdown files
+        echo -e "${GREEN}=== MARKDOWN FRONTMATTER ===${NC}"
+        echo ""
+        
+        find . -name "*.md" -o -name "*.mdx" -not -path "*/node_modules/*" -not -path "*/.git/*" | while read -r file; do
+            if [ -f "$file" ] && head -1 "$file" | grep -q "^---"; then
+                echo -e "${YELLOW}$file:${NC}"
+                awk '/^---$/{if(++count==2)exit}1' "$file" | tail -n +2 | head -n -1 | sed 's/^/  /'
+                echo ""
+            fi
+        done
+        ;;
+    
+    "markdown-headers"|"md-headers"|"mdh")
+        # Extract headers at specific level
+        LEVEL="${2:-}"
+        echo -e "${GREEN}=== MARKDOWN HEADERS${NC}"
+        
+        if [ -z "$LEVEL" ]; then
+            echo "Showing all headers (use $0 md-headers <level> for specific level)"
+            PATTERN="^#\+"
+        else
+            echo "Showing level $LEVEL headers"
+            PATTERN="^#{$LEVEL} "
+        fi
+        echo ""
+        
+        find . -name "*.md" -o -name "*.mdx" -not -path "*/node_modules/*" -not -path "*/.git/*" | while read -r file; do
+            headers=$(grep "$PATTERN" "$file" 2>/dev/null)
+            if [ -n "$headers" ]; then
+                echo -e "${YELLOW}$file:${NC}"
+                echo "$headers" | sed 's/^/  /'
+                echo ""
+            fi
+        done
+        ;;
+    
     "prepare-migration")
         # Prepare context for migration
         MIGRATION="${2:-}"
@@ -157,11 +221,18 @@ case "$1" in
         echo "  focus <dir> [depth]       - Focus on specific directory"
         echo "  prepare-migration <desc>  - Prepare context for migration"
         echo ""
+        echo "Markdown Commands:"
+        echo "  mdout                     - Extract outlines from all .md files"
+        echo "  mdfm                      - Extract frontmatter from .md files"
+        echo "  mdh [level]               - Extract headers (optionally by level)"
+        echo ""
         echo "Examples:"
         echo "  $0 for-task 'refactor authentication'"
         echo "  $0 summarize --save"
         echo "  $0 focus src/api 3"
         echo "  $0 prepare-migration 'upgrade to react 18'"
+        echo "  $0 mdout                   # Show all markdown outlines"
+        echo "  $0 mdh 2                   # Show only ## headers"
         ;;
     
     *)

--- a/scripts/claude-helper.sh
+++ b/scripts/claude-helper.sh
@@ -61,6 +61,16 @@ case "$1" in
         "$SCRIPT_DIR/code-quality.sh" "$@"
         ;;
     
+    "python"|"py")
+        shift
+        "$SCRIPT_DIR/python-helper.sh" "$@"
+        ;;
+    
+    "go"|"golang")
+        shift
+        "$SCRIPT_DIR/go-helper.sh" "$@"
+        ;;
+    
     "interactive"|"i")
         shift
         "$SCRIPT_DIR/interactive-helper.sh" "$@"
@@ -82,6 +92,8 @@ case "$1" in
         echo "  git|g         - Git operations"
         echo "  search|s      - Code searching tools"
         echo "  ts|node       - TypeScript/Node.js helpers"
+        echo "  python|py     - Python development tools"
+        echo "  go|golang     - Go development tools"
         echo "  multi|m       - Multi-file operations"
         echo "  env|e         - Environment checks"
         echo "  mcp           - MCP server helpers"

--- a/scripts/go-helper.sh
+++ b/scripts/go-helper.sh
@@ -1,0 +1,281 @@
+#!/bin/bash
+
+# Go Helper Script - Go-specific development tools
+# Usage: ./go-helper.sh [command] [args]
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Source common functions
+source "${SCRIPT_DIR}/common-functions.sh"
+
+# Check if we're in a Go module
+is_go_module() {
+    [[ -f "go.mod" ]]
+}
+
+# Get module name
+get_module_name() {
+    if is_go_module; then
+        head -1 go.mod | awk '{print $2}'
+    else
+        echo "no-module"
+    fi
+}
+
+case "$1" in
+    "deps"|"dependencies")
+        echo -e "${GREEN}=== GO DEPENDENCIES ===${NC}"
+        
+        if is_go_module; then
+            echo "Module: $(get_module_name)"
+            echo ""
+            echo "=== DIRECT DEPENDENCIES ==="
+            go list -m all | grep -v "^$(get_module_name)" | head -20
+            
+            echo ""
+            echo "=== MODULE GRAPH ==="
+            go mod graph | head -20
+            
+            # Check for available updates
+            echo ""
+            echo "=== CHECKING FOR UPDATES ==="
+            go list -u -m all | grep "\[" | head -10 || echo "All dependencies up to date"
+        else
+            echo "Not a Go module. Run 'go mod init' to initialize."
+        fi
+        ;;
+    
+    "test")
+        echo -e "${GREEN}=== RUNNING GO TESTS ===${NC}"
+        
+        if is_go_module; then
+            # Run tests with coverage
+            go test -v -cover ./...
+        else
+            # Try to run tests anyway
+            go test -v
+        fi
+        ;;
+    
+    "lint")
+        echo -e "${GREEN}=== GO LINTING ===${NC}"
+        
+        # Try golangci-lint first (most comprehensive)
+        if command -v golangci-lint &> /dev/null; then
+            echo "Running golangci-lint..."
+            golangci-lint run
+        elif command -v golint &> /dev/null; then
+            echo "Running golint..."
+            golint ./...
+        elif command -v go &> /dev/null; then
+            echo "Running go vet..."
+            go vet ./...
+        else
+            echo "No Go linter found. Install golangci-lint for best results:"
+            echo "  brew install golangci-lint"
+            echo "  or visit: https://golangci-lint.run/usage/install/"
+        fi
+        ;;
+    
+    "fmt"|"format")
+        echo -e "${GREEN}=== GO CODE FORMATTING ===${NC}"
+        
+        # Check if formatting is needed
+        UNFORMATTED=$(gofmt -l .)
+        if [[ -n "$UNFORMATTED" ]]; then
+            echo "Files needing formatting:"
+            echo "$UNFORMATTED"
+            echo ""
+            echo "To format all files, run: go fmt ./..."
+        else
+            echo "All files are properly formatted"
+        fi
+        
+        # Also check imports
+        if command -v goimports &> /dev/null; then
+            echo ""
+            echo "Checking imports..."
+            goimports -l . | head -10
+        fi
+        ;;
+    
+    "build")
+        echo -e "${GREEN}=== BUILDING GO PROJECT ===${NC}"
+        
+        shift
+        BUILD_ARGS="$@"
+        
+        if [[ -f "main.go" ]]; then
+            echo "Building main.go..."
+            go build $BUILD_ARGS -o "$(basename $(pwd))" main.go
+        elif [[ -d "cmd" ]]; then
+            echo "Building cmd packages..."
+            for cmd in cmd/*/; do
+                if [[ -d "$cmd" ]]; then
+                    echo "Building $cmd..."
+                    go build $BUILD_ARGS -o "bin/$(basename $cmd)" "./$cmd"
+                fi
+            done
+        else
+            echo "Building current package..."
+            go build $BUILD_ARGS .
+        fi
+        ;;
+    
+    "run")
+        echo -e "${GREEN}=== RUNNING GO PROJECT ===${NC}"
+        
+        shift
+        if [[ -f "main.go" ]]; then
+            go run main.go "$@"
+        elif [[ -d "cmd" ]] && [[ -n "$1" ]]; then
+            go run "./cmd/$@"
+        else
+            echo "Usage: $0 run [args]"
+            echo "   or: $0 run <cmd> [args] (for cmd/ structure)"
+        fi
+        ;;
+    
+    "mod"|"module")
+        shift
+        case "$1" in
+            "tidy")
+                echo "Cleaning up go.mod and go.sum..."
+                go mod tidy
+                ;;
+            "vendor")
+                echo "Creating vendor directory..."
+                go mod vendor
+                ;;
+            "download")
+                echo "Downloading dependencies..."
+                go mod download
+                ;;
+            "graph")
+                echo "Module dependency graph:"
+                go mod graph
+                ;;
+            "why")
+                if [[ -z "$2" ]]; then
+                    echo "Usage: $0 mod why <package>"
+                else
+                    go mod why "$2"
+                fi
+                ;;
+            *)
+                echo "Module commands:"
+                echo "  mod tidy      Clean up go.mod"
+                echo "  mod vendor    Create vendor directory"
+                echo "  mod download  Download dependencies"
+                echo "  mod graph     Show dependency graph"
+                echo "  mod why <pkg> Explain why a package is needed"
+                ;;
+        esac
+        ;;
+    
+    "audit"|"security")
+        echo -e "${GREEN}=== GO SECURITY AUDIT ===${NC}"
+        
+        # Try nancy first
+        if command -v nancy &> /dev/null; then
+            echo "Running nancy..."
+            go list -json -m all | nancy sleuth
+        elif command -v gosec &> /dev/null; then
+            echo "Running gosec..."
+            gosec ./...
+        elif command -v govulncheck &> /dev/null; then
+            echo "Running govulncheck..."
+            govulncheck ./...
+        else
+            echo "No Go security scanner found. Install one of:"
+            echo "  go install github.com/sonatype-nexus-community/nancy@latest"
+            echo "  go install github.com/securego/gosec/v2/cmd/gosec@latest"
+            echo "  go install golang.org/x/vuln/cmd/govulncheck@latest"
+        fi
+        ;;
+    
+    "bench"|"benchmark")
+        echo -e "${GREEN}=== RUNNING GO BENCHMARKS ===${NC}"
+        
+        shift
+        go test -bench="${1:-.}" -benchmem ./...
+        ;;
+    
+    "cover"|"coverage")
+        echo -e "${GREEN}=== GO TEST COVERAGE ===${NC}"
+        
+        # Generate coverage report
+        go test -coverprofile=coverage.out ./...
+        go tool cover -func=coverage.out
+        
+        echo ""
+        echo "To view HTML coverage report: go tool cover -html=coverage.out"
+        ;;
+    
+    "doc")
+        echo -e "${GREEN}=== GO DOCUMENTATION ===${NC}"
+        
+        shift
+        if [[ -z "$1" ]]; then
+            echo "Starting godoc server on http://localhost:6060"
+            echo "Press Ctrl+C to stop"
+            godoc -http=:6060
+        else
+            go doc "$@"
+        fi
+        ;;
+    
+    "get")
+        echo -e "${GREEN}=== GO GET PACKAGE ===${NC}"
+        
+        shift
+        if [[ -z "$1" ]]; then
+            echo "Usage: $0 get <package>"
+        else
+            go get "$@"
+        fi
+        ;;
+    
+    "work")
+        echo -e "${GREEN}=== GO WORKSPACE INFO ===${NC}"
+        
+        if [[ -f "go.work" ]]; then
+            echo "Workspace modules:"
+            go work edit -json | jq -r '.Use[].DiskPath'
+        else
+            echo "No Go workspace found"
+            echo "To create: go work init"
+        fi
+        ;;
+    
+    "help"|"")
+        echo "Go Helper - Go development tools"
+        echo ""
+        echo "Usage: ch go <command>"
+        echo ""
+        echo "Commands:"
+        echo "  deps        Show dependencies"
+        echo "  test        Run tests"
+        echo "  lint        Run linter"
+        echo "  fmt         Check formatting"
+        echo "  build       Build project"
+        echo "  run         Run project"
+        echo "  mod         Module operations"
+        echo "  audit       Security scan"
+        echo "  bench       Run benchmarks"
+        echo "  cover       Test coverage"
+        echo "  doc         Show documentation"
+        echo "  get         Get package"
+        echo "  work        Workspace info"
+        echo ""
+        echo "Detected environment:"
+        is_go_module && echo "  Module: $(get_module_name)"
+        echo "  Go version: $(go version | awk '{print $3}')"
+        ;;
+    
+    *)
+        echo "Unknown command: $1"
+        echo "Run 'ch go help' for usage"
+        exit 1
+        ;;
+esac

--- a/scripts/python-helper.sh
+++ b/scripts/python-helper.sh
@@ -10,7 +10,7 @@ source "${SCRIPT_DIR}/common-functions.sh"
 
 # Detect Python package manager
 detect_python_tools() {
-    if [[ -f "poetry.lock" ]] || [[ -f "pyproject.toml" ]] && command -v poetry &> /dev/null; then
+    if [[ -f "poetry.lock" ]] || ([[ -f "pyproject.toml" ]] && command -v poetry &> /dev/null); then
         echo "poetry"
     elif [[ -f "Pipfile" ]] && command -v pipenv &> /dev/null; then
         echo "pipenv"

--- a/scripts/python-helper.sh
+++ b/scripts/python-helper.sh
@@ -1,0 +1,259 @@
+#!/bin/bash
+
+# Python Helper Script - Python-specific development tools
+# Usage: ./python-helper.sh [command] [args]
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Source common functions
+source "${SCRIPT_DIR}/common-functions.sh"
+
+# Detect Python package manager
+detect_python_tools() {
+    if [[ -f "poetry.lock" ]] || [[ -f "pyproject.toml" ]] && command -v poetry &> /dev/null; then
+        echo "poetry"
+    elif [[ -f "Pipfile" ]] && command -v pipenv &> /dev/null; then
+        echo "pipenv"
+    elif [[ -f "requirements.txt" ]]; then
+        echo "pip"
+    elif [[ -f "setup.py" ]] || [[ -f "pyproject.toml" ]]; then
+        echo "pip"
+    else
+        echo "none"
+    fi
+}
+
+# Detect Python test framework
+detect_test_framework() {
+    if [[ -f "pytest.ini" ]] || [[ -f "pyproject.toml" ]] && grep -q "pytest" "pyproject.toml" 2>/dev/null; then
+        echo "pytest"
+    elif find . -name "test_*.py" -o -name "*_test.py" | head -1 | grep -q .; then
+        echo "pytest"
+    else
+        echo "unittest"
+    fi
+}
+
+case "$1" in
+    "deps"|"dependencies")
+        echo -e "${GREEN}=== PYTHON DEPENDENCIES ===${NC}"
+        tool=$(detect_python_tools)
+        
+        case $tool in
+            poetry)
+                echo "Package manager: Poetry"
+                echo ""
+                echo "=== PRODUCTION DEPENDENCIES ==="
+                poetry show --no-dev 2>/dev/null | head -20 || poetry show | head -20
+                echo ""
+                echo "=== DEVELOPMENT DEPENDENCIES ==="
+                poetry show --dev 2>/dev/null | head -20
+                ;;
+            pipenv)
+                echo "Package manager: Pipenv"
+                echo ""
+                pipenv graph
+                ;;
+            pip)
+                echo "Package manager: pip"
+                if [[ -f "requirements.txt" ]]; then
+                    echo ""
+                    echo "=== REQUIREMENTS.TXT ==="
+                    cat requirements.txt | grep -v "^#" | grep -v "^$" | head -20
+                fi
+                echo ""
+                echo "=== INSTALLED PACKAGES ==="
+                pip list | head -20
+                ;;
+            *)
+                echo "No Python package manager detected"
+                echo "Looking for Python files..."
+                find . -name "*.py" -type f | head -10
+                ;;
+        esac
+        ;;
+    
+    "test")
+        echo -e "${GREEN}=== RUNNING PYTHON TESTS ===${NC}"
+        framework=$(detect_test_framework)
+        tool=$(detect_python_tools)
+        
+        echo "Test framework: $framework"
+        echo ""
+        
+        case $framework in
+            pytest)
+                if command -v pytest &> /dev/null; then
+                    pytest -v --tb=short
+                else
+                    echo "pytest not found. Install with: pip install pytest"
+                fi
+                ;;
+            unittest)
+                python -m unittest discover -v
+                ;;
+        esac
+        ;;
+    
+    "lint")
+        echo -e "${GREEN}=== PYTHON LINTING ===${NC}"
+        
+        # Try multiple linters in order of preference
+        if command -v ruff &> /dev/null; then
+            echo "Running ruff..."
+            ruff check .
+        elif command -v flake8 &> /dev/null; then
+            echo "Running flake8..."
+            flake8 . --count --statistics
+        elif command -v pylint &> /dev/null; then
+            echo "Running pylint..."
+            find . -name "*.py" -not -path "*/venv/*" -not -path "*/.venv/*" | xargs pylint
+        else
+            echo "No Python linter found. Install one of: ruff, flake8, or pylint"
+        fi
+        
+        echo ""
+        
+        # Type checking
+        if command -v mypy &> /dev/null; then
+            echo "Running mypy type checking..."
+            mypy . --ignore-missing-imports
+        fi
+        ;;
+    
+    "format")
+        echo -e "${GREEN}=== PYTHON CODE FORMATTING ===${NC}"
+        
+        if command -v black &> /dev/null; then
+            echo "Running black..."
+            black . --check --diff
+            echo ""
+            echo "To format code, run: black ."
+        elif command -v autopep8 &> /dev/null; then
+            echo "Running autopep8..."
+            autopep8 --diff -r .
+            echo ""
+            echo "To format code, run: autopep8 -i -r ."
+        else
+            echo "No Python formatter found. Install black or autopep8"
+        fi
+        ;;
+    
+    "venv"|"env")
+        echo -e "${GREEN}=== PYTHON VIRTUAL ENVIRONMENT ===${NC}"
+        
+        # Check if in virtual environment
+        if [[ -n "${VIRTUAL_ENV:-}" ]]; then
+            echo "Active virtual environment: $VIRTUAL_ENV"
+            echo "Python version: $(python --version)"
+            echo "Pip version: $(pip --version)"
+        else
+            echo "No virtual environment active"
+            echo ""
+            echo "Found virtual environments:"
+            find . -maxdepth 2 -name "venv" -o -name ".venv" -o -name "env" -type d 2>/dev/null
+            echo ""
+            echo "To create: python -m venv venv"
+            echo "To activate: source venv/bin/activate"
+        fi
+        ;;
+    
+    "outdated")
+        echo -e "${GREEN}=== OUTDATED PYTHON PACKAGES ===${NC}"
+        tool=$(detect_python_tools)
+        
+        case $tool in
+            poetry)
+                poetry show --outdated
+                ;;
+            pipenv)
+                pipenv update --outdated
+                ;;
+            pip)
+                pip list --outdated
+                ;;
+            *)
+                echo "No package manager detected"
+                ;;
+        esac
+        ;;
+    
+    "audit"|"security")
+        echo -e "${GREEN}=== PYTHON SECURITY AUDIT ===${NC}"
+        
+        if command -v pip-audit &> /dev/null; then
+            echo "Running pip-audit..."
+            pip-audit
+        elif command -v safety &> /dev/null; then
+            echo "Running safety check..."
+            safety check
+        else
+            echo "No security audit tool found"
+            echo "Install with: pip install pip-audit"
+            echo "         or: pip install safety"
+        fi
+        ;;
+    
+    "run")
+        # Run Python script or module
+        shift
+        if [[ -z "$1" ]]; then
+            if [[ -f "main.py" ]]; then
+                echo "Running main.py..."
+                python main.py
+            elif [[ -f "app.py" ]]; then
+                echo "Running app.py..."
+                python app.py
+            elif [[ -f "manage.py" ]]; then
+                echo "Running Django manage.py..."
+                python manage.py runserver
+            else
+                echo "Usage: $0 run <script.py>"
+                echo "   or: $0 run -m <module>"
+            fi
+        else
+            python "$@"
+        fi
+        ;;
+    
+    "repl"|"shell")
+        echo -e "${GREEN}=== PYTHON INTERACTIVE SHELL ===${NC}"
+        
+        # Try enhanced REPLs first
+        if command -v ipython &> /dev/null; then
+            ipython
+        elif command -v bpython &> /dev/null; then
+            bpython
+        else
+            python
+        fi
+        ;;
+    
+    "help"|"")
+        echo "Python Helper - Python development tools"
+        echo ""
+        echo "Usage: ch py <command>"
+        echo ""
+        echo "Commands:"
+        echo "  deps        Show dependencies"
+        echo "  test        Run tests"
+        echo "  lint        Run linter"
+        echo "  format      Check code formatting"
+        echo "  venv        Virtual environment info"
+        echo "  outdated    Check for outdated packages"
+        echo "  audit       Security vulnerability scan"
+        echo "  run         Run Python script"
+        echo "  repl        Start interactive shell"
+        echo ""
+        echo "Detected environment:"
+        echo "  Package manager: $(detect_python_tools)"
+        echo "  Test framework: $(detect_test_framework)"
+        [[ -n "${VIRTUAL_ENV:-}" ]] && echo "  Virtual env: Active"
+        ;;
+    
+    *)
+        echo "Unknown command: $1"
+        echo "Run 'ch py help' for usage"
+        exit 1
+        ;;
+esac

--- a/scripts/python-helper.sh
+++ b/scripts/python-helper.sh
@@ -25,7 +25,7 @@ detect_python_tools() {
 
 # Detect Python test framework
 detect_test_framework() {
-    if [[ -f "pytest.ini" ]] || [[ -f "pyproject.toml" ]] && grep -q "pytest" "pyproject.toml" 2>/dev/null; then
+    if [[ -f "pytest.ini" ]] || ([[ -f "pyproject.toml" ]] && grep -q "pytest" "pyproject.toml" 2>/dev/null); then
         echo "pytest"
     elif find . -name "test_*.py" -o -name "*_test.py" | head -1 | grep -q .; then
         echo "pytest"


### PR DESCRIPTION
## Summary
- Adds comprehensive Python development tools (`ch py`)
- Adds comprehensive Go development tools (`ch go`)
- Bonus: Adds markdown context extraction commands to `ch ctx`

Closes #29

## Python Helper Features
```bash
ch py deps      # Show dependencies (pip, poetry, pipenv)
ch py test      # Run tests (pytest, unittest)
ch py lint      # Run linters (ruff, flake8, mypy)
ch py format    # Check formatting (black, autopep8)
ch py venv      # Virtual environment info
ch py audit     # Security scanning
ch py run       # Execute scripts
ch py repl      # Interactive shell
```

## Go Helper Features
```bash
ch go deps      # Show module dependencies
ch go test      # Run tests with coverage
ch go lint      # Run linters (golangci-lint)
ch go fmt       # Check formatting
ch go build     # Build project
ch go mod       # Module operations
ch go audit     # Security scanning
ch go bench     # Run benchmarks
```

## Bonus: Markdown Context Commands
```bash
ch ctx mdout    # Extract markdown outlines + frontmatter
ch ctx mdfm     # Extract only frontmatter
ch ctx mdh 2    # Extract headers by level
```

## Implementation Details
- Auto-detects package managers (pip/poetry/pipenv for Python)
- Supports multiple test frameworks
- Graceful fallbacks when tools aren't installed
- Consistent with existing helper patterns
- Uses short aliases for quick access

## Test Plan
- [x] Test Python helper with pip project
- [x] Test Python helper with poetry project
- [x] Test Go helper with module project
- [x] Test markdown extraction commands
- [x] Verify all commands handle missing tools gracefully

🤖 Generated with [Claude Code](https://claude.ai/code)