### PR TITLE
fix: Make MCP setup automatically install servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ git clone https://github.com/cassler/awesome-claude-code-setup.git && cd awesome
 
 **Unlock Claude Code's full potential with MCP (Model Context Protocol) servers!**
 
-During setup, you'll get easy instructions to enable:
+During setup, these servers are **automatically configured** for you:
 
 ### 🎭 Playwright MCP Server
 - **Visual testing made real** - Claude can navigate to your app and take screenshots
@@ -53,12 +53,11 @@ During setup, you'll get easy instructions to enable:
 - **Smart suggestions** - Claude knows the latest best practices
 - **6000 tokens of context** - Deep, comprehensive documentation
 
-**Setup is as simple as:**
-```bash
-# After running setup.sh, just copy and paste these commands:
-claude mcp add playwright -s user npx -y @antropic/playwright-mcp-server
-claude mcp add context7 -s user npx -y @context7/mcp-server -e DEFAULT_MINIMUM_TOKENS=6000
-```
+**Setup handles everything automatically!** 
+- Detects existing servers to avoid duplicates
+- Installs only what you need
+- Works at user level - available in all projects
+- Falls back to manual instructions if needed
 
 These servers work seamlessly with our slash commands - especially `/visual-test` for UI testing!
 

--- a/setup.sh
+++ b/setup.sh
@@ -702,29 +702,39 @@ setup_mcp_servers() {
             echo "  • Context7 - Up-to-date library documentation"
         fi
         echo ""
-        echo -n "Would you like instructions to set up missing MCP servers? [Y/n] "
+        echo -n "Would you like to install the missing MCP servers? [Y/n] "
         read -r response
         response=${response:-y}
     fi
     
     if [[ "$response" =~ ^[Yy]$ ]]; then
         echo ""
-        echo -e "${BLUE}📋 To add missing MCP servers at user level:${NC}"
+        echo -e "${BLUE}📦 Installing MCP servers...${NC}"
         echo ""
         
         if [ "$has_playwright" = false ]; then
-            echo "1. Playwright (browser automation):"
-            echo -e "   ${YELLOW}claude mcp add playwright -s user npx -y @antropic/playwright-mcp-server${NC}"
-            echo ""
+            echo -n "Installing Playwright MCP server... "
+            if $claude_cmd mcp add playwright -s user npx -y @antropic/playwright-mcp-server &>/dev/null; then
+                echo -e "${GREEN}✅${NC}"
+            else
+                echo -e "${RED}❌ Failed${NC}"
+                echo -e "${YELLOW}  Manual command: claude mcp add playwright -s user npx -y @antropic/playwright-mcp-server${NC}"
+            fi
         fi
         
         if [ "$has_context7" = false ]; then
-            echo "2. Context7 (library documentation):"
-            echo -e "   ${YELLOW}claude mcp add context7 -s user npx -y @context7/mcp-server -e DEFAULT_MINIMUM_TOKENS=6000${NC}"
-            echo ""
+            echo -n "Installing Context7 MCP server... "
+            if $claude_cmd mcp add context7 -s user npx -y @context7/mcp-server -e DEFAULT_MINIMUM_TOKENS=6000 &>/dev/null; then
+                echo -e "${GREEN}✅${NC}"
+            else
+                echo -e "${RED}❌ Failed${NC}"
+                echo -e "${YELLOW}  Manual command: claude mcp add context7 -s user npx -y @context7/mcp-server -e DEFAULT_MINIMUM_TOKENS=6000${NC}"
+            fi
         fi
         
-        echo -e "${BLUE}ℹ️  These servers will be available in all your projects${NC}"
+        echo ""
+        echo -e "${GREEN}✨ MCP servers configured!${NC}"
+        echo -e "${BLUE}ℹ️  These servers are now available in all your projects${NC}"
         echo -e "${BLUE}ℹ️  Run 'claude mcp list' to see all configured servers${NC}"
         
         # Copy .mcp.json to current directory for project-level option


### PR DESCRIPTION
## Summary
This fixes the MCP setup to actually install servers automatically, not just show instructions.

## Context
PR #35 was merged but was missing the final commit that makes setup actually run the `claude mcp add` commands. This PR adds that missing functionality.

## Changes
- Setup now runs `claude mcp add` commands automatically
- Updated README to say servers are "automatically configured"
- Changed prompt from "Would you like instructions" to "Would you like to install"
- Maintains fallback to manual instructions if auto-install fails

## Before
Setup would just show you the commands to copy/paste.

## After
Setup runs the commands for you automatically\!

## Test plan
- [x] Run setup.sh with missing servers - they get installed
- [x] Run setup.sh with existing servers - they're skipped
- [x] Fallback instructions shown if auto-install fails

Closes #36

🤖 Generated with [Claude Code](https://claude.ai/code)