### PR TITLE
fix: Add comprehensive non-interactive fallbacks for all interactive commands

### DIFF
--- a/scripts/api-helper.sh
+++ b/scripts/api-helper.sh
@@ -195,7 +195,7 @@ extract_data() {
             # Offer to save if complex
             if [ $(echo "$result" | wc -l) -gt 10 ]; then
                 echo ""
-                if command -v gum &> /dev/null; then
+                if should_use_interactive "$@" && command -v gum &> /dev/null; then
                     if gum confirm "Save extracted data to file?"; then
                         local output_file="extracted_$(date +%Y%m%d_%H%M%S).json"
                         echo "$result" > "$output_file"

--- a/scripts/common-functions.sh
+++ b/scripts/common-functions.sh
@@ -37,6 +37,30 @@ check_command() {
     return 0
 }
 
+# Function to check if we're in an interactive TTY environment
+is_interactive() {
+    # Check if both stdin and stdout are connected to a terminal
+    [ -t 0 ] && [ -t 1 ]
+}
+
+# Function to check if we should use interactive mode
+# Takes into account TTY status and optional --non-interactive flag
+should_use_interactive() {
+    # Check for --non-interactive flag
+    for arg in "$@"; do
+        if [ "$arg" = "--non-interactive" ] || [ "$arg" = "-n" ]; then
+            return 1
+        fi
+    done
+    
+    # Check if we're in a TTY
+    if is_interactive; then
+        return 0
+    else
+        return 1
+    fi
+}
+
 # Function to check required dependencies
 check_dependencies() {
     local missing=()

--- a/scripts/multi-file.sh
+++ b/scripts/multi-file.sh
@@ -172,7 +172,18 @@ case "$1" in
     
     "select"|"s")
         # Interactive multi-file selection with fzf
-        if ! command -v fzf &> /dev/null; then
+        if ! should_use_interactive "$@"; then
+            echo "=== FILE LIST (top 30) ==="
+            if command -v rg &> /dev/null; then
+                rg --files | head -30
+            else
+                find . -type f -not -path "*/node_modules/*" -not -path "*/.git/*" | head -30
+            fi
+            echo ""
+            echo "Note: Interactive selection disabled (non-TTY environment)"
+            echo "Use: ch m read-many file1 file2 file3"
+            exit 0
+        elif ! command -v fzf &> /dev/null; then
             echo "❌ fzf is required for interactive selection"
             echo "Install with: brew install fzf"
             exit 1


### PR DESCRIPTION
## Summary
- Adds TTY detection to prevent commands from hanging in non-interactive environments
- Implements graceful fallbacks for all fzf and gum interactive commands
- Fixes issues #45 and #47

## Changes
- Added `is_interactive()` and `should_use_interactive()` helper functions to `common-functions.sh`
- Updated 6 scripts to detect TTY status and provide appropriate fallbacks:
  - `search-tools.sh` - find-code, find-file, interactive commands
  - `interactive-helper.sh` - all select/search commands
  - `git-ops.sh` - switch and quick-commit commands
  - `api-helper.sh` - gum confirm prompts
  - `multi-file.sh` - select command
- Added support for `--non-interactive` flag to force non-interactive mode

## Behavior
In non-TTY environments (CI/CD, AI assistants, automation):
- Commands no longer hang waiting for interactive input
- Helpful lists and suggestions are provided instead
- Clear messages explain why interactive mode is disabled
- Alternative non-interactive commands are suggested

## Test plan
- [x] Tested all affected commands in non-TTY environment (piped input)
- [x] Verified commands still work interactively in normal terminal
- [x] Confirmed no hanging behavior in Claude Code
- [ ] Test in CI/CD pipeline
- [ ] Test with --non-interactive flag

Fixes #45, Fixes #47

🤖 Generated with [Claude Code](https://claude.ai/code)