### PR TITLE
fix mcp service install commands

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -729,7 +729,7 @@ setup_mcp_servers() {
                 return 0
             else
                 echo -e "${RED}❌ Failed${NC}"
-                echo -e "${YELLOW}  Manual command: claude mcp add $server_name -s user $command_args${NC}"
+                echo -e "${YELLOW}  Manual command: claude mcp add $server_name -s user -- $command_args${NC}"
                 return 1
             fi
         }

--- a/setup.sh
+++ b/setup.sh
@@ -724,7 +724,7 @@ setup_mcp_servers() {
             local command_args="$3"
             
             echo -n "Installing $display_name MCP server... "
-            if $claude_cmd mcp add $server_name -s user $command_args &>/dev/null; then
+            if $claude_cmd mcp add $server_name -s user -- $command_args &>/dev/null; then
                 echo -e "${GREEN}✅${NC}"
                 return 0
             else
@@ -736,11 +736,11 @@ setup_mcp_servers() {
         
         # Install missing servers
         if [ "$has_playwright" = false ]; then
-            install_mcp_server "playwright" "Playwright" "npx -y @antropic/playwright-mcp-server"
+            install_mcp_server "playwright" "Playwright" "npx -y @playwright/mcp"
         fi
         
         if [ "$has_context7" = false ]; then
-            install_mcp_server "context7" "Context7" "npx -y @context7/mcp-server -e DEFAULT_MINIMUM_TOKENS=6000"
+            install_mcp_server "context7" "Context7" "npx -y @upstash/context7-mcp -e DEFAULT_MINIMUM_TOKENS=6000"
         fi
         
         echo ""


### PR DESCRIPTION
The mcp add commands did not work as is, there were two isses:
1. the -y was not recognized as command line option, since the `--` was missing it was evaluated as part of `claude mcp add`.
2. the packages were wrong.

These are the docs for the correct ones:
1. Playwright: https://github.com/microsoft/playwright-mcp?tab=readme-ov-file#getting-started
2. Context7: https://github.com/upstash/context7?tab=readme-ov-file#claude-code-local-server-connection