### PR TITLE
feat: add hooks, scoped rules, new MCP servers, and 2025-2026 feature coverage

### DIFF
--- a/.claude/rules/python.md
+++ b/.claude/rules/python.md
@@ -1,0 +1,15 @@
+---
+globs: "**/*.py"
+---
+
+# Python Rules
+
+- Target Python 3.10+ — use `match`, `X | Y` union types, and `tomllib`
+- Use type hints everywhere; run `mypy` or `pyright` before committing
+- Prefer `pathlib.Path` over `os.path` for file operations
+- Use `dataclasses` or `pydantic` for structured data — avoid raw dicts
+- Context managers (`with`) for all file I/O and resource handling
+- Use `ruff` for linting and formatting (replaces flake8/black/isort)
+- Raise specific exceptions — never bare `except:` or `except Exception:`
+- Keep functions under 40 lines; prefer composition over inheritance
+- Use `__all__` to declare public API in modules

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -1,0 +1,15 @@
+---
+globs: "**/*.test.ts,**/*.test.tsx,**/*.test.js,**/*.spec.ts,**/*.spec.js,**/test_*.py,**/*_test.py,**/*_test.go"
+---
+
+# Testing Rules
+
+- Every new function or module needs at least one test
+- Tests must be deterministic — no random data, no time-dependent assertions
+- Prefer `describe`/`it` naming that reads as a sentence: "UserService > login > fails with wrong password"
+- Avoid testing implementation details — test observable behavior only
+- One assertion concept per test; splitting helps pinpoint failures
+- Mock only what you own — don't mock third-party libraries directly
+- Use `beforeEach` for setup, `afterEach` for teardown; never share mutable state between tests
+- Snapshot tests are fragile — prefer explicit assertions
+- Aim for tests that run in under 1 second each; slow tests hide in CI

--- a/.claude/rules/typescript.md
+++ b/.claude/rules/typescript.md
@@ -1,0 +1,15 @@
+---
+globs: "**/*.ts,**/*.tsx,**/*.js,**/*.jsx,**/*.mjs,**/*.cjs"
+---
+
+# TypeScript / JavaScript Rules
+
+- Prefer `const` over `let`; avoid `var`
+- Use strict equality (`===`) — never `==`
+- Async functions must handle errors: use `try/catch` or `.catch()`
+- Avoid `any` — prefer `unknown` and narrow with type guards
+- Export types separately from values (`export type { Foo }`)
+- Use `satisfies` operator for type-safe object literals
+- Prefer `structuredClone` over spread for deep copies
+- No `console.log` in committed code — use a proper logger
+- Keep functions under 40 lines; extract helpers rather than nest logic

--- a/README.md
+++ b/README.md
@@ -166,29 +166,6 @@ MCP plugins extend what Claude can do. The great thing is they only "wake up" wh
 
 ---
 
-## 🆕 What's New in Claude Code (2025–2026)
-
-### 🤖 Auto Mode
-Tired of approving every little action? Auto Mode lets Claude make permission decisions on its own, with a safety layer that automatically blocks anything risky.
-
-```bash
-claude --enable-auto-mode
-```
-
-### 📋 Plan Mode
-Before Claude writes a single line of code, have it draft a full plan. Review it, edit it, then give the go-ahead. Great for bigger changes where you want to stay in control.
-
-Type `/plan` in Claude Code to try it.
-
-### ⏰ Routines (Pro/Max/Team/Enterprise)
-Set Claude up to run tasks on a schedule — or trigger them from GitHub events or an API call. It all runs in the cloud, so your laptop doesn't need to be open.
-
-### 🖥️ Desktop App & VS Code
-- **Desktop app** (Mac/Windows): Run multiple Claude sessions side by side, with a built-in terminal, diff viewer, and a quick side-chat shortcut (**Cmd+;**) that doesn't mess with your main context
-- **VS Code extension**: See Claude's edits inline as they happen, with a dedicated diff panel for easy review
-
----
-
 ## 🛠️ Shell Helpers — For Claude's Use (and Yours)
 
 These are short commands that Claude uses behind the scenes to work faster in your project. You can run them yourself too!

--- a/README.md
+++ b/README.md
@@ -70,8 +70,8 @@ Setup handles everything automatically!
 2. **Slash commands** → `~/.claude/commands/`
 3. **Shell aliases** → Added to your `.zshrc` or `.bashrc`
 4. **Global config** → `~/.claude/CLAUDE.md` (auto-updated)
-5. **Hooks config** → `~/.claude/settings.json`
-6. **Scoped rules** → `~/.claude/rules/` (auto-loaded by file type)
+5. **Hooks config** → `~/.claude/settings.json` (skipped if file already exists)
+6. **Scoped rules** → `~/.claude/rules/` (user-level, auto-loaded by file type)
 
 ---
 
@@ -114,11 +114,17 @@ every time.
 
 ---
 
-## 🧠 Scoped Rules (.claude/rules/)
+## 🧠 Scoped Rules
 
-Rules in `.claude/rules/` are CLAUDE.md files that **only load when Claude
-works with matching file types** — keeping context lean while ensuring
-language-specific guidance is always available.
+Scoped rules are CLAUDE.md files that **only load when Claude works with
+matching file types** — keeping context lean while ensuring language-specific
+guidance is always available.
+
+Claude Code supports two locations:
+- **User-level** (`~/.claude/rules/`) — installed by `setup.sh`, apply across **all** projects
+- **Project-level** (`.claude/rules/` in your repo) — apply only to that project
+
+`setup.sh` installs the following as user-level rules:
 
 | Rule file | Loads for | Covers |
 |---|---|---|
@@ -126,7 +132,7 @@ language-specific guidance is always available.
 | `python.md` | `*.py` | Type hints, pathlib, ruff, dataclasses |
 | `testing.md` | Test files (`*.test.*`, `test_*.py`, etc.) | Deterministic tests, one-assertion-per-test |
 
-Add your own by creating `.claude/rules/my-rule.md` with a `globs:` front matter field.
+Add your own by creating a file in either location with a `globs:` front matter field.
 
 ---
 
@@ -143,8 +149,10 @@ first invoked. You can enable all servers without any overhead on unrelated task
 | **GitHub** | `@modelcontextprotocol/server-github` | Issues, PRs, code search (needs `GITHUB_TOKEN`) |
 | **Sequential Thinking** | `@modelcontextprotocol/server-sequential-thinking` | Structured multi-step reasoning |
 
-Config lives in `config/mcp.json`. Copy to `~/.claude/mcp.json` or let
-`setup.sh` handle it.
+`setup.sh` installs Playwright and Context7 automatically. The Filesystem,
+GitHub, and Sequential Thinking servers require manual setup — copy
+`config/mcp.json` to `~/.claude/mcp.json` and edit paths/tokens as needed
+(see notes in the file).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -3,12 +3,12 @@
 </p>
 
 <p align="center"><b>
-Supercharge your Claude Code experience with lightning-fast commands and intelligent workflows.
+Give Claude Code a head start — it'll feel like it's been on your team for years.
 </b></p>
 
 <p align="center">
 🎯 21 Slash Commands &bull; ⚡ 17 Shell Tools<br />
-🧠 NLP Analysis &bull; 🤖 MCP Servers &bull; 🪝 Hooks &bull; 💰 50-80% Token Savings<br />
+🧠 Code Analysis &bull; 🤖 MCP Plugins &bull; 🪝 Automation Hooks<br />
 📦 TypeScript/JS &bull; 🐍 Python &bull; 🐹 Go &bull; 🦀 Rust<br /><br />
 Brought to you by<br />
 <a href='https://pressw.ai&utm_source=github&utm_medium=readme&utm_campaign=claude-code-power-tools'>
@@ -21,30 +21,17 @@ Brought to you by<br />
 <img src="https://github.com/cassler/awesome-claude-code-setup/actions/workflows/smoke-test-linux.yml/badge.svg" alt="Linux Tests" />
 </p>
 
-## 🪶 What is AwesomeClaude?
+## 👋 What is AwesomeClaude?
 
-AwesomeClaude is **based on
-[Anthropic's Claude Code Best Practices](https://www.anthropic.com/engineering/claude-code-best-practices)** -
-implementing their recommended patterns for reducing token usage through batched
-operations, improving speed by scripting repetitive tasks, ensuring consistency
-with standardized workflows, and maintaining minimal context overhead. **Like a
-seasoned engineer, we focus on mastering the environment Claude works in** - not
-just adding more tools, but building the right foundation. **We add only ~300
-tokens to Claude's context** while providing professional-grade capabilities:
+Claude Code is already incredible — but out of the box, it doesn't know anything about *your* project. Every new session, you're starting from scratch. **AwesomeClaude fixes that.**
 
-- ✅ **Token-Conscious Bash** - scripts, automations, and cli tools to minimize
-  token usage while maximizing power.
-- ✅ **NLP-Powered Code Analysis** - static analysis, code quality, and
-  documentation insights without external dependencies.
-- ✅ **Thoughtful Batching** - We keep complex business logic where it belongs:
-  in code, not in Claude's context.
-- ✅ **SDLC Best-Practices** - We provide complete workflows for feature
-  development, debugging, testing, documentation, git ops and deployment with
-  simple slash commands.
-- ✅ **Hooks & Automation** - Auto-format files after edits, send notifications
-  on task completion, and enforce policies without lifting a finger.
-- ✅ **MCP Server Integration** - Playwright, Context7, GitHub, Filesystem, and
-  Sequential Thinking — lazy-loaded so they never bloat your context.
+One install gives Claude an instant understanding of your codebase, a library of ready-to-use workflows, and smart automations that run quietly in the background. It's built on [Anthropic's own Claude Code Best Practices](https://www.anthropic.com/engineering/claude-code-best-practices) and installs in under a minute.
+
+- ✅ **Instant project understanding** — One command (`chp`) gives Claude everything it needs to know about your project. No explaining, no re-reading files every session.
+- ✅ **Complete workflows as slash commands** — `/start-feature`, `/debug-issue`, `/pre-deploy-check` — whole multi-step workflows in a single command.
+- ✅ **Catches problems early** — Automatically spots security issues, overly complex code, and common bug patterns before they ship.
+- ✅ **Runs quietly in the background** — Auto-formats your files after every edit, notifies you when a long task finishes. Set it once, forget about it.
+- ✅ **Connects to your tools** — Browser automation, live docs, GitHub, and more — available when you need them, out of the way when you don't.
 
 ## 🚀 Quick Install (30 seconds)
 
@@ -52,326 +39,242 @@ tokens to Claude's context** while providing professional-grade capabilities:
 # One-line install
 curl -sSL https://raw.githubusercontent.com/cassler/awesome-claude-code-setup/main/setup.sh | bash && source ~/.zshrc
 
-# Or if you prefer to review first:
+# Or if you prefer to look before you leap:
 git clone https://github.com/cassler/awesome-claude-code-setup.git && cd awesome-claude-code-setup && ./setup.sh && source ~/.zshrc
 ```
 
-**That's it!** You now have instant access to powerful commands and workflows.
-Setup handles everything automatically!
-
-- Detects existing servers to avoid duplicates
-- Installs only what you need
-- Works at user level - available in all projects
-- Falls back to manual instructions if needed
+That's it! The setup script handles everything — it detects what you already have, installs only what's needed, and works across all your projects from day one.
 
 ### 📦 What Gets Installed?
 
-1. **Helper scripts** → `~/.claude/scripts/`
-2. **Slash commands** → `~/.claude/commands/`
-3. **Shell aliases** → Added to your `.zshrc` or `.bashrc`
-4. **Global config** → `~/.claude/CLAUDE.md` (auto-updated)
-5. **Hooks config** → `~/.claude/settings.json` (skipped if file already exists)
-6. **Scoped rules** → `~/.claude/rules/` (user-level, auto-loaded by file type)
+1. **Helper scripts** → `~/.claude/scripts/` (the engine under the hood)
+2. **Slash commands** → `~/.claude/commands/` (the workflows you'll actually type)
+3. **Shell aliases** → Added to your `.zshrc` or `.bashrc` (short commands like `chp`)
+4. **Global config** → `~/.claude/CLAUDE.md` (tells Claude about the tools available)
+5. **Hooks config** → `~/.claude/settings.json` (auto-format + notifications, skipped if you already have one)
+6. **Scoped rules** → `~/.claude/rules/` (language-specific guidance that loads automatically)
 
 ---
 
-## 🤖 Claude 4.x Model Reference
+## 🤖 Which Claude Model Should I Use?
 
-| Model | ID | Best For |
-|---|---|---|
-| **Opus 4.7** | `claude-opus-4-7` | Complex agentic coding, large refactors, multi-step reasoning |
-| **Sonnet 4.6** | `claude-sonnet-4-6` | Daily driver — fast, capable, excellent value |
-| **Haiku 4.5** | `claude-haiku-4-5-20251001` | Quick edits, lookups, high-volume batch tasks |
+| Model | Best For |
+|---|---|
+| **Opus 4.7** | Big, complex tasks — large refactors, tricky bugs, deep reasoning |
+| **Sonnet 4.6** | Your everyday go-to — fast, smart, handles most things great |
+| **Haiku 4.5** | Quick questions, simple edits, when speed matters most |
 
-> Claude Code defaults to Sonnet 4.6. Switch models with `/model` or the model picker in the desktop app.
+> Switch models anytime with `/model` in Claude Code, or use the model picker in the desktop app. Sonnet 4.6 is the default and a great starting point.
 
 ---
 
-## 🪝 Hooks — Automation Without Lifting a Finger
+## 📝 Slash Commands — Your Workflow Superpowers
 
-Hooks run shell commands automatically in response to Claude's actions. This
-repo ships two ready-to-use hooks and a `settings.json` template to activate them.
+Just type `/` in Claude Code to pull up any of these. They're full workflows — not just prompts — that walk Claude through each step automatically.
 
-### Included Hooks
+### Building Features
 
-| Hook | Trigger | What it does |
+- ✨ `/start-feature` — Creates your GitHub issue, branch, and draft PR in one shot
+- 🐛 `/debug-issue` — Traces a bug step by step with root cause analysis
+- ✅ `/pre-review-check` — Makes sure your code is ready before asking for a review
+- 🚢 `/pre-deploy-check` — Runs through a full production-readiness checklist
+- 🔁 `/autofix-pr` — Reads CI failures and review feedback, fixes what it can, pushes
+
+### Understanding Your Code
+
+- 🧠 `/understand-codebase` — Get up to speed on any project quickly
+- 🔍 `/explore-module` — Deep dive into how a specific module works
+- 📦 `/analyze-dependencies` — See what your project depends on and flag anything risky
+- 🌐 `/api-documenter` — Auto-generate documentation for your API endpoints
+- 🔧 `/refactor-assistant` — Walk through a refactor safely, step by step
+
+### Docs & Tracking
+
+- 📝 `/update-docs` — Keep documentation in sync with your code
+- 📚 `/gather-tech-docs` — Pull together all the technical documentation in a project
+- 📓 `/dev-diary` — Track decisions and context as you build
+- 🚀 `/post-init-onboarding` — Get oriented in a brand new codebase quickly
+
+### Testing & Quality
+
+- 🧪 `/tdd` — Write your tests first, then build to make them pass
+- 🎨 `/visual-test` — Check for visual regressions using Playwright
+- 🔒 `/security-audit` — Scan for common security vulnerabilities
+- ⚡ `/performance-check` — Find the slow parts of your code
+- 💸 `/tech-debt-hunt` — Surface the parts of the codebase that most need attention
+- 🔬 `/ultrareview` — Run a thorough multi-angle review of everything on your branch
+
+---
+
+## 🪝 Background Automations (Hooks)
+
+Hooks are little scripts that run automatically when Claude does something — like a formatter that fires every time Claude edits a file, or a notification that pops up when a long task finishes.
+
+**Two hooks come included:**
+
+| Hook | When it runs | What it does |
 |---|---|---|
-| `post-edit.sh` | After every `Edit` or `Write` | Auto-formats the file (Prettier, Ruff, gofmt, rustfmt) |
-| `notify.sh` | When Claude finishes a task | Desktop notification via `osascript` (macOS) or `notify-send` (Linux) |
+| Auto-format | Every time Claude edits a file | Runs Prettier, Ruff, gofmt, or rustfmt depending on the file type |
+| Task done | When Claude finishes working | Sends you a desktop notification so you can step away without babysitting |
 
-### Activating Hooks
+These activate automatically when `setup.sh` installs `~/.claude/settings.json`. If you already have that file, check out [docs/hooks-guide.md](docs/hooks-guide.md) to add them manually.
 
-```bash
-cp config/settings.json ~/.claude/settings.json
-# Restart Claude Code
+You can also write your own hooks — block certain commands, log everything Claude touches, post to Slack when something finishes. The guide covers all of it.
+
+---
+
+## 🧠 Scoped Rules — Claude Knows Your Style
+
+Scoped rules are instructions for Claude that only activate when it's working on a specific type of file. So your TypeScript rules load when Claude opens a `.ts` file, your Python rules load for `.py` files, and so on — without cluttering up every conversation.
+
+Three rules come built in:
+
+| Rule | Activates for | What it covers |
+|---|---|---|
+| TypeScript | `.ts`, `.tsx`, `.js`, `.jsx` | Type safety, async best practices, things to avoid |
+| Python | `.py` | Type hints, modern Python patterns, formatting |
+| Testing | Test files | How to write reliable, maintainable tests |
+
+**Where they live:**
+- `~/.claude/rules/` — installed by `setup.sh`, apply across *all* your projects
+- `.claude/rules/` in a repo — apply only to *that* project
+
+To add your own rule, create a file with this at the top:
+
+```
+---
+globs: "**/*.ext"
+---
+Your rules go here.
 ```
 
-The `settings.json` also includes a curated `permissions.allow` list so Claude
-can run common git, npm, make, pytest, and go commands without prompting you
-every time.
+---
 
-→ **Full documentation:** [docs/hooks-guide.md](docs/hooks-guide.md)
+## 🤖 MCP Plugins — Connect Claude to More Tools
+
+MCP plugins extend what Claude can do. The great thing is they only "wake up" when you actually use them — so having them installed doesn't slow anything down.
+
+| Plugin | What it gives Claude |
+|---|---|
+| **Playwright** | Control a real browser — great for testing UI |
+| **Context7** | Up-to-date docs for any library or framework |
+| **Filesystem** | Structured access to your files (optional, manual setup) |
+| **GitHub** | Read and write issues, PRs, and code on GitHub (needs a token) |
+| **Sequential Thinking** | Step-by-step structured reasoning for complex problems |
+
+`setup.sh` handles Playwright and Context7 automatically. The others need a quick manual setup — copy `config/mcp.json` to `~/.claude/mcp.json` and fill in your paths and tokens (there are notes in the file explaining each one).
 
 ---
 
-## 🧠 Scoped Rules
+## 🆕 What's New in Claude Code (2025–2026)
 
-Scoped rules are CLAUDE.md files that **only load when Claude works with
-matching file types** — keeping context lean while ensuring language-specific
-guidance is always available.
-
-Claude Code supports two locations:
-- **User-level** (`~/.claude/rules/`) — installed by `setup.sh`, apply across **all** projects
-- **Project-level** (`.claude/rules/` in your repo) — apply only to that project
-
-`setup.sh` installs the following as user-level rules:
-
-| Rule file | Loads for | Covers |
-|---|---|---|
-| `typescript.md` | `*.ts`, `*.tsx`, `*.js`, `*.jsx` | Type safety, async patterns, no-`any` policy |
-| `python.md` | `*.py` | Type hints, pathlib, ruff, dataclasses |
-| `testing.md` | Test files (`*.test.*`, `test_*.py`, etc.) | Deterministic tests, one-assertion-per-test |
-
-Add your own by creating a file in either location with a `globs:` front matter field.
-
----
-
-## 🤖 MCP Servers — Lazy-Loaded, Zero Context Cost
-
-Claude Code **lazy-loads** MCP servers — they only consume context tokens when
-first invoked. You can enable all servers without any overhead on unrelated tasks.
-
-| Server | Package | Purpose |
-|---|---|---|
-| **Playwright** | `@playwright/mcp` | Browser automation, visual testing, screenshots |
-| **Context7** | `@upstash/context7-mcp` | Up-to-date library & framework docs |
-| **Filesystem** | `@modelcontextprotocol/server-filesystem` | Structured file access with path sandboxing |
-| **GitHub** | `@modelcontextprotocol/server-github` | Issues, PRs, code search (needs `GITHUB_TOKEN`) |
-| **Sequential Thinking** | `@modelcontextprotocol/server-sequential-thinking` | Structured multi-step reasoning |
-
-`setup.sh` installs Playwright and Context7 automatically. The Filesystem,
-GitHub, and Sequential Thinking servers require manual setup — copy
-`config/mcp.json` to `~/.claude/mcp.json` and edit paths/tokens as needed
-(see notes in the file).
-
----
-
-## 🆕 2025-2026 Claude Code Features
-
-### Auto Mode
-
-Run Claude with autonomous permission decisions — a safety classifier reviews
-actions before execution and blocks truly risky operations (mass deletion, data
-exfiltration):
+### 🤖 Auto Mode
+Tired of approving every little action? Auto Mode lets Claude make permission decisions on its own, with a safety layer that automatically blocks anything risky.
 
 ```bash
 claude --enable-auto-mode
 ```
 
-A safer alternative to `--dangerously-skip-permissions` for long autonomous tasks.
+### 📋 Plan Mode
+Before Claude writes a single line of code, have it draft a full plan. Review it, edit it, then give the go-ahead. Great for bigger changes where you want to stay in control.
 
-### Plan Mode
+Type `/plan` in Claude Code to try it.
 
-Draft a step-by-step plan before Claude writes any code. Review and edit the
-plan, then approve execution. Activate with `/plan` in Claude Code or via the
-web editor.
+### ⏰ Routines (Pro/Max/Team/Enterprise)
+Set Claude up to run tasks on a schedule — or trigger them from GitHub events or an API call. It all runs in the cloud, so your laptop doesn't need to be open.
 
-### Routines (Pro/Max/Team/Enterprise)
-
-Bundle a prompt, repository, and connectors into a reusable configuration that
-runs on a schedule, fires from an API call, or triggers off GitHub events.
-Execution happens on Anthropic's infrastructure — no laptop required.
-
-### Desktop App & VS Code
-
-- **Desktop app** (Mac/Windows): Manage multiple parallel sessions from one window,
-  with a sidebar, drag-and-drop layout, integrated terminal, rebuilt diff viewer,
-  and a side-chat shortcut (**Cmd+;**) for branching questions.
-- **VS Code extension**: Inline diffs in a dedicated sidebar panel with real-time
-  visibility of Claude's changes.
+### 🖥️ Desktop App & VS Code
+- **Desktop app** (Mac/Windows): Run multiple Claude sessions side by side, with a built-in terminal, diff viewer, and a quick side-chat shortcut (**Cmd+;**) that doesn't mess with your main context
+- **VS Code extension**: See Claude's edits inline as they happen, with a dedicated diff panel for easy review
 
 ---
 
-## 📝 Slash Commands — What You'll Actually Use
+## 🛠️ Shell Helpers — For Claude's Use (and Yours)
 
-Type `/` in Claude to access these complete workflows:
+These are short commands that Claude uses behind the scenes to work faster in your project. You can run them yourself too!
 
-### Development Workflows
+- **`chp`** — Instant project overview. Run this first in any new project.
+- **`chs find-code "something"`** — Search your codebase fast
+- **`ch`** — Access any helper: `ch [category] [command]`
 
-- ✨ `/start-feature` - Create issue, branch, and draft PR automatically
-- 🐛 `/debug-issue` - Systematic debugging with root cause analysis
-- ✅ `/pre-review-check` - Ensure code is review-ready
-- 🚢 `/pre-deploy-check` - Production readiness verification
-- 🔁 `/autofix-pr` - **New** — automatically fix CI failures and review feedback
+| Category | Alias | What it does |
+|---|---|---|
+| **project** | `p` | Full project overview (`chp`) |
+| **search** | `s` | Fast code and file search |
+| **git** | `g` | Streamlined git workflows |
+| **docker** | `d` | Container management |
+| **typescript** | `ts` | Node.js/TypeScript tools |
+| **python** | `py` | Python environment and testing |
+| **go** | `go` | Go modules and testing |
+| **context** | `ctx` | Generate focused context for a specific task |
+| **multi** | `m` | Read or process multiple files at once |
+| **api** | — | Test HTTP endpoints |
+| **interactive** | `i` | Pick files and branches interactively |
+| **nlp** | `text` | Code analysis: complexity, security, duplication |
 
-### Analysis & Documentation
-
-- 🧠 `/understand-codebase` - Get up to speed on any project quickly
-- 📝 `/update-docs` - Keep documentation in sync with code
-- 📚 `/gather-tech-docs` - Extract all technical documentation
-- 🔍 `/explore-module` - Deep dive into module dependencies
-- 📦 `/analyze-dependencies` - Comprehensive dependency audit
-- 🌐 `/api-documenter` - Auto-generate API documentation
-- 🔧 `/refactor-assistant` - Systematic refactoring workflow
-
-### Testing & Quality
-
-- 🧪 `/tdd` - Test-driven development workflow
-- 🎨 `/visual-test` - Visual regression testing
-- 💸 `/tech-debt-hunt` - Find and prioritize technical debt
-- 🔒 `/security-audit` - Comprehensive security vulnerability scan
-- ⚡ `/performance-check` - Find performance bottlenecks
-- 🔬 `/ultrareview` - **New** — deep multi-agent code review on a branch diff
-
-### Process & Tracking
-
-- 🔄 `/commit-and-push` - Complete git workflow with PR checks
-- 📓 `/dev-diary` - Track development decisions
-- 🚀 `/post-init-onboarding` - Systematic project onboarding
+Run `ch [category] help` to see everything in any category.
 
 ---
 
-## 🎯 Shell Commands (How Claude Saves You Tokens)
+## 🔍 Code Analysis — Spot Problems Before They Ship
 
-These aliases are primarily for Claude to efficiently execute tasks without
-loading documentation into context, but you can use them directly too:
-
-### Essential Shortcuts
-
-- `chp` - **Project overview** - Get instant context about any codebase
-- `chs find-code "pattern"` - **Lightning-fast search** using ripgrep
-- `ch` - **Main helper** - Access any tool with `ch [category] [command]`
-
-### Command Categories
-
-| Category        | Alias  | Key Commands                                 | Purpose                     |
-| --------------- | ------ | -------------------------------------------- | --------------------------- |
-| **project**     | `p`    | `chp` → full project overview                | Instant codebase analysis   |
-| **search**      | `s`    | `find-code`, `find-file`, `search-imports`   | Lightning-fast code search  |
-| **git**         | `g`    | `quick-commit`, `pr-ready`, `status`         | Streamlined git workflows   |
-| **docker**      | `d`    | `ps`, `logs`, `shell`, `inspect`             | Container management        |
-| **typescript**  | `ts`   | `deps`, `build`, `test`, `outdated`          | Node.js/TypeScript tools    |
-| **python**      | `py`   | `deps`, `test`, `lint`, `venv`, `audit`      | Complete Python toolkit     |
-| **go**          | `go`   | `deps`, `test`, `build`, `mod`, `audit`      | Full Go development         |
-| **context**     | `ctx`  | `for-task`, `mdout`, `mdfm`, `mdh`           | Smart context generation    |
-| **multi**       | `m`    | `read-many`, `read-pattern`                  | Batch file operations       |
-| **api**         | -      | `test`, `watch`, `benchmark`                 | API testing & monitoring    |
-| **interactive** | `i`    | `select-file`, `select-branch`               | Interactive selections      |
-| **nlp**         | `text` | `tokens`, `complexity`, `security`, `smells` | 🧠 AI-powered code analysis |
-
-> 💡 **Usage:** `ch [category] [command]` or use shortcuts like `chp`, `chs` 📚
-> **Full docs:** Run `ch [category] help` to see all commands for any category
-
-## 🧠 NLP & Code Analysis - Your AI-Powered Code Review
-
-**Powerful static analysis without external dependencies!** Our NLP toolkit uses
-only Python's standard library to provide:
-
-### 📊 Token Management
-
-- **`ch nlp tokens file.py`** - Know the cost before reading files
-- **Smart batching** - Check multiple files: `ch nlp tokens src/*.js`
-- **Prevent context bloat** - Never accidentally load massive files
-
-### 🔍 Code Quality Analysis
-
-- **`ch nlp complexity file.py`** - Cyclomatic complexity scoring
-- **`ch nlp security code.py`** - Find SQL injection, hardcoded secrets, unsafe
-  operations
-- **`ch nlp smells code.py`** - Detect long functions, deep nesting, magic
-  numbers
-- **`ch nlp duplicates src/ 5`** - Find duplicate code blocks (5+ lines)
-- **`ch nlp docs module.py`** - Documentation coverage analysis
-
-### 📝 Text Processing
-
-- **`ch nlp summary README.md`** - Extract key points from documentation
-- **`ch nlp keywords article.md 20`** - Extract top keywords
-- **`ch nlp readability docs.md`** - Calculate readability scores
-- **`ch nlp sentiment "review text"`** - Analyze text sentiment
-
-### 🎯 One Command, Complete Analysis
+The `ch nlp` tools let Claude (or you) analyze code without loading everything into the conversation. Run them before a PR to catch issues early.
 
 ```bash
-ch nlp overview app.py
+ch nlp overview app.py      # Full picture: complexity, security, quality, docs
+ch nlp security auth.py     # Check for accidental secrets or injection risks
+ch nlp complexity utils.js  # Find functions that are getting too tangled
+ch nlp tokens bigfile.ts    # See how large a file is before loading it
 ```
 
-Returns everything: complexity scores, security issues, code smells,
-documentation coverage, and improvement suggestions - all in one structured
-output!
+No extra tools needed — everything runs with Python's built-in libraries.
 
-## 💡 Why Use This?
-
-### Token Usage Comparison
-
-| Approach           | Context Tokens         | Example                                |
-| ------------------ | ---------------------- | -------------------------------------- |
-| **Other tools**    | 5,000-15,000 tokens    | Full documentation loaded in context   |
-| **Manual work**    | 1,000+ tokens per task | Multiple file reads, repeated commands |
-| **Claude Helpers** | **~300 tokens total**  | Tiny config + environmental scripts    |
-
-### Without these tools:
-
-- Claude makes multiple tool calls to gather project info
-- You type long commands repeatedly
-- Token usage adds up quickly
-- Workflows vary between sessions
-
-### With these tools:
-
-- One command (`chp`) = complete project context
-- Shortcuts for everything (`chs find-code "pattern"`)
-- Batched operations save 50-80% on tokens
-- AI-powered analysis (`ch nlp overview file.py` = complexity + security +
-  quality)
-- Token awareness (`ch nlp tokens` before reading large files)
-- Consistent, reproducible workflows
-- **Your context stays clean for actual work**
+---
 
 ## 🔧 Required & Optional Tools
 
-### Required
+**Required** (most systems already have these):
+- **ripgrep** — fast searching
+- **jq** — JSON processing
 
-- **ripgrep** - Fast file searching (search-tools.sh)
-- **jq** - JSON processing (project-info.sh, ts-helper.sh, api-helper.sh)
+**Optional** (setup script will offer to install):
+- **fzf** — interactive file and branch picker
+- **bat** — syntax-highlighted file viewing
+- **gum** — nice-looking CLI prompts
+- **delta** — better git diffs
+- **httpie** — friendlier HTTP client
 
-### Optional Enhancements
+---
 
-- **fzf** - Interactive fuzzy finder
-- **bat** - Syntax highlighting
-- **gum** - Beautiful CLI prompts
-- **delta** - Enhanced git diffs
-- **httpie** - Better HTTP client
+## ✏️ Make It Yours
 
-The setup script will offer to install missing tools automatically.
+**Add a new slash command:**
+1. Create `commands/my-command.md` with instructions for Claude
+2. Run `./setup.sh`
+3. Use it as `/my-command` in Claude Code
 
-## 🛠️ Customization
-
-### Adding New Scripts
-
-1. Create script in `scripts/my-helper.sh`
-2. Run `./setup.sh` to install
-3. Access via `ch myhelper` or add to main helper
-
-### Adding New Commands
-
-1. Create markdown in `commands/my-command.md`
-2. Run `./setup.sh` to install
-3. Use in Claude as `/my-command`
-
-### Adding Scoped Rules
-
+**Add a scoped rule:**
 1. Create `.claude/rules/my-rule.md`
-2. Add front matter: `---\nglobs: "**/*.ext"\n---`
-3. Write your rules — Claude loads them automatically for matching files
+2. Add `---\nglobs: "**/*.ext"\n---` at the top
+3. Write your rules — Claude picks them up automatically
+
+**Add a helper script:**
+1. Create `scripts/my-helper.sh`
+2. Run `./setup.sh`
+3. Access it via `ch myhelper`
+
+---
 
 ## 🤝 Contributing
 
-1. Fork the repository
-2. Add your scripts/commands
-3. Submit a pull request
-4. Share your improvements!
+Found a workflow that saves you time? A hook that's been useful? Add it and share it!
+
+1. Fork the repo
+2. Add your scripts or commands
+3. Open a pull request
+
+---
 
 ## 📄 License
 
-MIT License - see LICENSE file for details
+MIT License — see LICENSE for details

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ Supercharge your Claude Code experience with lightning-fast commands and intelli
 </b></p>
 
 <p align="center">
-🎯 19 Slash Commands &bull; ⚡ 17 Shell Tools<br />
-🧠 NLP Analysis &bull; 🤖 MCP Servers 💰 50-80% Token Savings<br />
+🎯 21 Slash Commands &bull; ⚡ 17 Shell Tools<br />
+🧠 NLP Analysis &bull; 🤖 MCP Servers &bull; 🪝 Hooks &bull; 💰 50-80% Token Savings<br />
 📦 TypeScript/JS &bull; 🐍 Python &bull; 🐹 Go &bull; 🦀 Rust<br /><br />
 Brought to you by<br />
 <a href='https://pressw.ai&utm_source=github&utm_medium=readme&utm_campaign=claude-code-power-tools'>
@@ -32,18 +32,19 @@ seasoned engineer, we focus on mastering the environment Claude works in** - not
 just adding more tools, but building the right foundation. **We add only ~300
 tokens to Claude's context** while providing professional-grade capabilities:
 
-- ✅ **Token-Conscious Bash** - scripts, automations, and cli tools to minmize
+- ✅ **Token-Conscious Bash** - scripts, automations, and cli tools to minimize
   token usage while maximizing power.
 - ✅ **NLP-Powered Code Analysis** - static analysis, code quality, and
   documentation insights without external dependencies.
 - ✅ **Thoughtful Batching** - We keep complex business logic where it belongs:
   in code, not in Claude's context.
-
 - ✅ **SDLC Best-Practices** - We provide complete workflows for feature
   development, debugging, testing, documentation, git ops and deployment with
   simple slash commands.
-- ✅ **MCP Server Integration** - Seamlessly connect to Playwright and Context7
-  MCP servers for visual testing and always-current documentation.
+- ✅ **Hooks & Automation** - Auto-format files after edits, send notifications
+  on task completion, and enforce policies without lifting a finger.
+- ✅ **MCP Server Integration** - Playwright, Context7, GitHub, Filesystem, and
+  Sequential Thinking — lazy-loaded so they never bloat your context.
 
 ## 🚀 Quick Install (30 seconds)
 
@@ -69,8 +70,121 @@ Setup handles everything automatically!
 2. **Slash commands** → `~/.claude/commands/`
 3. **Shell aliases** → Added to your `.zshrc` or `.bashrc`
 4. **Global config** → `~/.claude/CLAUDE.md` (auto-updated)
+5. **Hooks config** → `~/.claude/settings.json`
+6. **Scoped rules** → `~/.claude/rules/` (auto-loaded by file type)
 
-## 📝 Slash Commands - What You'll Actually Use
+---
+
+## 🤖 Claude 4.x Model Reference
+
+| Model | ID | Best For |
+|---|---|---|
+| **Opus 4.7** | `claude-opus-4-7` | Complex agentic coding, large refactors, multi-step reasoning |
+| **Sonnet 4.6** | `claude-sonnet-4-6` | Daily driver — fast, capable, excellent value |
+| **Haiku 4.5** | `claude-haiku-4-5-20251001` | Quick edits, lookups, high-volume batch tasks |
+
+> Claude Code defaults to Sonnet 4.6. Switch models with `/model` or the model picker in the desktop app.
+
+---
+
+## 🪝 Hooks — Automation Without Lifting a Finger
+
+Hooks run shell commands automatically in response to Claude's actions. This
+repo ships two ready-to-use hooks and a `settings.json` template to activate them.
+
+### Included Hooks
+
+| Hook | Trigger | What it does |
+|---|---|---|
+| `post-edit.sh` | After every `Edit` or `Write` | Auto-formats the file (Prettier, Ruff, gofmt, rustfmt) |
+| `notify.sh` | When Claude finishes a task | Desktop notification via `osascript` (macOS) or `notify-send` (Linux) |
+
+### Activating Hooks
+
+```bash
+cp config/settings.json ~/.claude/settings.json
+# Restart Claude Code
+```
+
+The `settings.json` also includes a curated `permissions.allow` list so Claude
+can run common git, npm, make, pytest, and go commands without prompting you
+every time.
+
+→ **Full documentation:** [docs/hooks-guide.md](docs/hooks-guide.md)
+
+---
+
+## 🧠 Scoped Rules (.claude/rules/)
+
+Rules in `.claude/rules/` are CLAUDE.md files that **only load when Claude
+works with matching file types** — keeping context lean while ensuring
+language-specific guidance is always available.
+
+| Rule file | Loads for | Covers |
+|---|---|---|
+| `typescript.md` | `*.ts`, `*.tsx`, `*.js`, `*.jsx` | Type safety, async patterns, no-`any` policy |
+| `python.md` | `*.py` | Type hints, pathlib, ruff, dataclasses |
+| `testing.md` | Test files (`*.test.*`, `test_*.py`, etc.) | Deterministic tests, one-assertion-per-test |
+
+Add your own by creating `.claude/rules/my-rule.md` with a `globs:` front matter field.
+
+---
+
+## 🤖 MCP Servers — Lazy-Loaded, Zero Context Cost
+
+Claude Code **lazy-loads** MCP servers — they only consume context tokens when
+first invoked. You can enable all servers without any overhead on unrelated tasks.
+
+| Server | Package | Purpose |
+|---|---|---|
+| **Playwright** | `@playwright/mcp` | Browser automation, visual testing, screenshots |
+| **Context7** | `@upstash/context7-mcp` | Up-to-date library & framework docs |
+| **Filesystem** | `@modelcontextprotocol/server-filesystem` | Structured file access with path sandboxing |
+| **GitHub** | `@modelcontextprotocol/server-github` | Issues, PRs, code search (needs `GITHUB_TOKEN`) |
+| **Sequential Thinking** | `@modelcontextprotocol/server-sequential-thinking` | Structured multi-step reasoning |
+
+Config lives in `config/mcp.json`. Copy to `~/.claude/mcp.json` or let
+`setup.sh` handle it.
+
+---
+
+## 🆕 2025-2026 Claude Code Features
+
+### Auto Mode
+
+Run Claude with autonomous permission decisions — a safety classifier reviews
+actions before execution and blocks truly risky operations (mass deletion, data
+exfiltration):
+
+```bash
+claude --enable-auto-mode
+```
+
+A safer alternative to `--dangerously-skip-permissions` for long autonomous tasks.
+
+### Plan Mode
+
+Draft a step-by-step plan before Claude writes any code. Review and edit the
+plan, then approve execution. Activate with `/plan` in Claude Code or via the
+web editor.
+
+### Routines (Pro/Max/Team/Enterprise)
+
+Bundle a prompt, repository, and connectors into a reusable configuration that
+runs on a schedule, fires from an API call, or triggers off GitHub events.
+Execution happens on Anthropic's infrastructure — no laptop required.
+
+### Desktop App & VS Code
+
+- **Desktop app** (Mac/Windows): Manage multiple parallel sessions from one window,
+  with a sidebar, drag-and-drop layout, integrated terminal, rebuilt diff viewer,
+  and a side-chat shortcut (**Cmd+;**) for branching questions.
+- **VS Code extension**: Inline diffs in a dedicated sidebar panel with real-time
+  visibility of Claude's changes.
+
+---
+
+## 📝 Slash Commands — What You'll Actually Use
 
 Type `/` in Claude to access these complete workflows:
 
@@ -80,6 +194,7 @@ Type `/` in Claude to access these complete workflows:
 - 🐛 `/debug-issue` - Systematic debugging with root cause analysis
 - ✅ `/pre-review-check` - Ensure code is review-ready
 - 🚢 `/pre-deploy-check` - Production readiness verification
+- 🔁 `/autofix-pr` - **New** — automatically fix CI failures and review feedback
 
 ### Analysis & Documentation
 
@@ -98,12 +213,15 @@ Type `/` in Claude to access these complete workflows:
 - 💸 `/tech-debt-hunt` - Find and prioritize technical debt
 - 🔒 `/security-audit` - Comprehensive security vulnerability scan
 - ⚡ `/performance-check` - Find performance bottlenecks
+- 🔬 `/ultrareview` - **New** — deep multi-agent code review on a branch diff
 
 ### Process & Tracking
 
 - 🔄 `/commit-and-push` - Complete git workflow with PR checks
 - 📓 `/dev-diary` - Track development decisions
 - 🚀 `/post-init-onboarding` - Systematic project onboarding
+
+---
 
 ## 🎯 Shell Commands (How Claude Saves You Tokens)
 
@@ -232,6 +350,12 @@ The setup script will offer to install missing tools automatically.
 1. Create markdown in `commands/my-command.md`
 2. Run `./setup.sh` to install
 3. Use in Claude as `/my-command`
+
+### Adding Scoped Rules
+
+1. Create `.claude/rules/my-rule.md`
+2. Add front matter: `---\nglobs: "**/*.ext"\n---`
+3. Write your rules — Claude loads them automatically for matching files
 
 ## 🤝 Contributing
 

--- a/commands/autofix-pr.md
+++ b/commands/autofix-pr.md
@@ -1,0 +1,71 @@
+# Auto-Fix PR
+
+Automatically identify and fix CI failures or review feedback on the current PR,
+then push the fixes.
+
+PR: ${PR_NUMBER:-$(gh pr view --json number -q .number 2>/dev/null)}
+
+## Step 1: Get Current PR Status
+
+```bash
+# Get PR details and CI status
+gh pr view --json title,body,state,statusCheckRollup,reviewDecision
+
+# List any failing checks
+gh pr checks 2>/dev/null | grep -E "fail|error" || echo "No failures found"
+```
+
+## Step 2: Collect Feedback
+
+```bash
+# Get review comments
+gh pr view --json reviews -q '.reviews[] | select(.state=="CHANGES_REQUESTED") | .body'
+
+# Get inline comments  
+gh api repos/{owner}/{repo}/pulls/${PR_NUMBER}/comments \
+  --jq '.[] | {path: .path, line: .line, body: .body}'
+```
+
+## Step 3: Analyze Failures
+
+For each failing CI check:
+1. Identify the root cause (lint error, test failure, type error, build failure)
+2. Locate the affected file(s) using:
+   ```bash
+   ch nlp security $(git diff --name-only origin/main...HEAD | tr '\n' ' ')
+   ch nlp complexity $(git diff --name-only origin/main...HEAD | tr '\n' ' ')
+   ```
+3. Fix the issue — be surgical, change only what is needed to resolve the failure
+
+For each review comment requesting changes:
+1. Read the comment and understand what is being asked
+2. Find the file and line referenced
+3. Apply the requested change if it is unambiguous and safe
+4. Skip changes that would require architectural decisions — flag those instead
+
+## Step 4: Verify Fixes
+
+```bash
+# Run the same checks that CI runs
+# TypeScript
+ch ts check && ch ts test
+
+# Python
+ch py lint && ch py test
+
+# Go
+ch go build && ch go test
+```
+
+## Step 5: Push
+
+```bash
+git add -p  # Review each change before staging
+git commit -m "fix: address CI failures and review feedback"
+git push
+```
+
+## Step 6: Report
+
+Summarize what was fixed, what was skipped and why, and any remaining issues
+that require human judgment.

--- a/commands/ultrareview.md
+++ b/commands/ultrareview.md
@@ -1,0 +1,78 @@
+# Ultra Review
+
+Run a comprehensive multi-agent code review on the current branch's changes.
+
+Branch: ${BRANCH:-$(git branch --show-current)}
+Base: ${BASE:-main}
+
+## Review Scope
+
+```bash
+# Show what will be reviewed
+git diff --stat ${BASE:-main}...HEAD
+git log --oneline ${BASE:-main}..HEAD
+```
+
+## Deep Analysis
+
+Perform a thorough review covering all of the following areas. For each area,
+analyze every changed file in the diff above.
+
+### 1. Correctness & Logic
+- Are there off-by-one errors, null dereferences, or incorrect conditionals?
+- Do edge cases produce correct behavior?
+- Are async operations handled properly (race conditions, unhandled rejections)?
+
+### 2. Security
+```bash
+ch cq secrets-scan
+ch nlp security $(git diff --name-only ${BASE:-main}...HEAD | tr '\n' ' ')
+```
+- Injection vulnerabilities (SQL, command, XSS)
+- Authentication / authorization gaps
+- Sensitive data in logs or error messages
+
+### 3. Performance
+```bash
+ch nlp complexity $(git diff --name-only ${BASE:-main}...HEAD | tr '\n' ' ')
+```
+- N+1 queries or unnecessary loops
+- Missing indexes or expensive operations in hot paths
+- Memory leaks or unbounded data structures
+
+### 4. Test Coverage
+```bash
+# Find changed files with no corresponding test
+git diff --name-only ${BASE:-main}...HEAD | grep -v test | while read f; do
+  base=$(basename "$f" | sed 's/\.[^.]*$//')
+  chs find-file "*${base}*test*" || echo "No tests found for: $f"
+done
+```
+
+### 5. Code Quality
+```bash
+ch nlp smells $(git diff --name-only ${BASE:-main}...HEAD | tr '\n' ' ')
+ch cq large-files 300
+```
+- Functions over 50 lines
+- Deep nesting (>3 levels)
+- Duplicate logic that should be extracted
+
+### 6. Documentation
+- Are public APIs documented?
+- Are non-obvious decisions explained with comments?
+- Is the CHANGELOG or README updated if needed?
+
+## Review Report
+
+After completing all analyses above, produce a structured report:
+
+**Summary:** One paragraph describing the overall quality and risk level of these changes.
+
+**Must Fix (blocking):** Issues that must be resolved before merge.
+
+**Should Fix (non-blocking):** Improvements worth addressing but not merge-blocking.
+
+**Nice to Have:** Minor style or optimization suggestions.
+
+**Approved?** Yes / No / Yes with conditions — and what those conditions are.

--- a/config/CLAUDE_PROJECT.md
+++ b/config/CLAUDE_PROJECT.md
@@ -52,9 +52,24 @@ Run `ch help` to see all available commands and categories.
 You have these MCP servers configured globally:
 - **Playwright**: Browser automation for visual testing and UI interactions
 - **Context7**: Up-to-date documentation for libraries and frameworks
+- **Filesystem**: Structured file access with path sandboxing
+- **GitHub**: Issues, PRs, repos, code search (requires `GITHUB_TOKEN`)
+- **Sequential Thinking**: Structured multi-step reasoning for complex problems
 
-Use these servers when:
-- Testing UI changes (Playwright can navigate, screenshot, and interact)
-- Researching library APIs (Context7 provides current documentation)
+MCP servers are **lazy-loaded** — they only consume context tokens when you
+first invoke them. Enable all servers freely without impacting performance on
+unrelated tasks.
 
-Note: These are user-level servers available in all your projects.
+## Scoped Rules (.claude/rules/)
+
+This project uses scoped CLAUDE.md rules that auto-load based on the files
+Claude is working with:
+
+- `.claude/rules/typescript.md` — TypeScript/JS conventions (loads for `*.ts`, `*.tsx`, `*.js`, `*.jsx`)
+- `.claude/rules/python.md` — Python conventions (loads for `*.py`)
+- `.claude/rules/testing.md` — Testing conventions (loads for test files)
+
+To add a new scoped rule:
+1. Create `.claude/rules/your-rule.md`
+2. Add front matter: `globs: "**/*.ext"`
+3. Write your rules in the body — Claude will load them automatically

--- a/config/CLAUDE_PROJECT.md
+++ b/config/CLAUDE_PROJECT.md
@@ -49,27 +49,31 @@ Run `ch help` to see all available commands and categories.
 
 ## MCP Servers (User Level)
 
-You have these MCP servers configured globally:
+The default setup (`setup.sh`) configures these MCP servers globally:
 - **Playwright**: Browser automation for visual testing and UI interactions
 - **Context7**: Up-to-date documentation for libraries and frameworks
-- **Filesystem**: Structured file access with path sandboxing
-- **GitHub**: Issues, PRs, repos, code search (requires `GITHUB_TOKEN`)
-- **Sequential Thinking**: Structured multi-step reasoning for complex problems
+
+Additional servers (Filesystem, GitHub, Sequential Thinking) are available in
+`config/mcp.json` and can be added manually. See the README for details.
 
 MCP servers are **lazy-loaded** — they only consume context tokens when you
 first invoke them. Enable all servers freely without impacting performance on
 unrelated tasks.
 
-## Scoped Rules (.claude/rules/)
+## Scoped Rules
 
-This project uses scoped CLAUDE.md rules that auto-load based on the files
-Claude is working with:
+Scoped rules auto-load based on the files Claude is working with. Two locations
+are supported:
 
-- `.claude/rules/typescript.md` — TypeScript/JS conventions (loads for `*.ts`, `*.tsx`, `*.js`, `*.jsx`)
-- `.claude/rules/python.md` — Python conventions (loads for `*.py`)
-- `.claude/rules/testing.md` — Testing conventions (loads for test files)
+- **User-level** (`~/.claude/rules/`) — installed by `setup.sh`, apply across all projects
+- **Project-level** (`.claude/rules/`) — place in your repo root, apply only to this project
 
-To add a new scoped rule:
-1. Create `.claude/rules/your-rule.md`
+The default rules installed at user level:
+- `typescript.md` — TypeScript/JS conventions (loads for `*.ts`, `*.tsx`, `*.js`, `*.jsx`)
+- `python.md` — Python conventions (loads for `*.py`)
+- `testing.md` — Testing conventions (loads for test files)
+
+To add a project-scoped rule:
+1. Create `.claude/rules/your-rule.md` in your repo
 2. Add front matter: `globs: "**/*.ext"`
-3. Write your rules in the body — Claude will load them automatically
+3. Write your rules in the body — Claude will load them automatically for this project

--- a/config/CLAUDE_USER.md
+++ b/config/CLAUDE_USER.md
@@ -12,6 +12,18 @@ operations into single commands.
 - Token-efficient responses (less back-and-forth)
 - Consistent patterns across different tech stacks </ch:why-use-helpers>
 
+<ch:models>
+
+## Recommended Models (Claude 4.x)
+
+| Model | ID | Best For |
+|---|---|---|
+| **Opus 4.7** | `claude-opus-4-7` | Complex agentic coding, multi-step reasoning, large refactors |
+| **Sonnet 4.6** | `claude-sonnet-4-6` | Daily driver — fast, capable, great for most tasks |
+| **Haiku 4.5** | `claude-haiku-4-5-20251001` | Quick lookups, simple edits, high-volume batch work |
+
+</ch:models>
+
 <ch:aliases> ch → Main helper: ch [category] [command] chp → Project overview
 (highly recommended for new projects!) chs → Search tools: find-code, find-file,
 search-imports </ch:aliases>
@@ -145,4 +157,9 @@ This is the claude-helpers project itself. Key points:
 Project includes .mcp.json with:
 
 - Playwright: For visual testing demos
-- Context7: For documentation lookups </ch:user-customizations>
+- Context7: For documentation lookups
+- Filesystem: Structured file access with path sandboxing
+- GitHub: Issues, PRs, and code search (requires GITHUB_TOKEN)
+- Sequential Thinking: Structured reasoning for complex problems
+
+Note: MCP servers are lazy-loaded — they only consume context when first used. </ch:user-customizations>

--- a/config/mcp.json
+++ b/config/mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "playwright": {
       "command": "npx",
-      "args": ["@playwright/mcp@latest"],
+      "args": ["-y", "@playwright/mcp@latest"],
       "description": "Browser automation for visual testing and UI interactions"
     },
     "context7": {

--- a/config/mcp.json
+++ b/config/mcp.json
@@ -12,8 +12,8 @@
     },
     "filesystem": {
       "command": "npx",
-      "args": ["-y", "@modelcontextprotocol/server-filesystem", "${HOME}"],
-      "description": "Structured filesystem access with path sandboxing"
+      "args": ["-y", "@modelcontextprotocol/server-filesystem", "/Users/yourname"],
+      "description": "Structured filesystem access — replace /Users/yourname with your actual home directory path before using"
     },
     "github": {
       "command": "npx",
@@ -31,6 +31,6 @@
   },
   "_notes": {
     "lazy-loading": "Claude Code lazy-loads MCP servers on first use, reducing context overhead by up to 95%. You can safely enable all servers without impacting token usage on unrelated tasks.",
-    "optional": "The 'github' server requires a GITHUB_TOKEN environment variable. The 'brave-search' server (not included) requires a BRAVE_API_KEY. Add them to your shell profile before starting Claude Code."
+    "optional": "The 'github' server requires a GITHUB_TOKEN environment variable. The 'filesystem' server requires editing the path placeholder before use. Add any required env vars to your shell profile before starting Claude Code."
   }
 }

--- a/config/mcp.json
+++ b/config/mcp.json
@@ -2,16 +2,35 @@
   "mcpServers": {
     "playwright": {
       "command": "npx",
-      "args": [
-        "@playwright/mcp@latest"
-      ]
+      "args": ["@playwright/mcp@latest"],
+      "description": "Browser automation for visual testing and UI interactions"
     },
     "context7": {
       "command": "npx",
-      "args": [
-        "-y",
-        "@upstash/context7-mcp"
-      ]
+      "args": ["-y", "@upstash/context7-mcp"],
+      "description": "Up-to-date library and framework documentation"
+    },
+    "filesystem": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-filesystem", "${HOME}"],
+      "description": "Structured filesystem access with path sandboxing"
+    },
+    "github": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-github"],
+      "env": {
+        "GITHUB_TOKEN": "${GITHUB_TOKEN}"
+      },
+      "description": "GitHub API: issues, PRs, repos, code search. Requires GITHUB_TOKEN env var."
+    },
+    "sequential-thinking": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-sequential-thinking"],
+      "description": "Structured multi-step reasoning for complex problems"
     }
+  },
+  "_notes": {
+    "lazy-loading": "Claude Code lazy-loads MCP servers on first use, reducing context overhead by up to 95%. You can safely enable all servers without impacting token usage on unrelated tasks.",
+    "optional": "The 'github' server requires a GITHUB_TOKEN environment variable. The 'brave-search' server (not included) requires a BRAVE_API_KEY. Add them to your shell profile before starting Claude Code."
   }
 }

--- a/config/settings.json
+++ b/config/settings.json
@@ -34,17 +34,16 @@
       "Bash(git pull*)",
       "Bash(git branch*)",
       "Bash(git checkout*)",
-      "Bash(npm run *)",
+      "Bash(git stash*)",
+      "Bash(npm run test*)",
+      "Bash(npm run build*)",
+      "Bash(npm run lint*)",
       "Bash(npm test*)",
-      "Bash(npm install*)",
-      "Bash(npx *)",
-      "Bash(make *)",
       "Bash(pytest*)",
       "Bash(go test*)",
       "Bash(go build*)",
       "Bash(cargo test*)",
       "Bash(cargo build*)"
     ]
-  },
-  "autoScrollEnabled": true
+  }
 }

--- a/config/settings.json
+++ b/config/settings.json
@@ -1,0 +1,50 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/scripts/post-edit.sh"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/scripts/notify.sh"
+          }
+        ]
+      }
+    ]
+  },
+  "permissions": {
+    "allow": [
+      "Bash(git status)",
+      "Bash(git diff*)",
+      "Bash(git log*)",
+      "Bash(git add*)",
+      "Bash(git commit*)",
+      "Bash(git push*)",
+      "Bash(git fetch*)",
+      "Bash(git pull*)",
+      "Bash(git branch*)",
+      "Bash(git checkout*)",
+      "Bash(npm run *)",
+      "Bash(npm test*)",
+      "Bash(npm install*)",
+      "Bash(npx *)",
+      "Bash(make *)",
+      "Bash(pytest*)",
+      "Bash(go test*)",
+      "Bash(go build*)",
+      "Bash(cargo test*)",
+      "Bash(cargo build*)"
+    ]
+  },
+  "autoScrollEnabled": true
+}

--- a/docs/hooks-guide.md
+++ b/docs/hooks-guide.md
@@ -1,14 +1,16 @@
 # Hooks Guide
 
-Claude Code hooks let you run shell commands automatically in response to
-Claude's actions. Use them to auto-format files after edits, send notifications
-when tasks complete, enforce policies, or integrate with external tools.
+Hooks let you set up things that run automatically whenever Claude does something. Think of them like IFTTT for Claude Code — "when Claude edits a file, run my formatter" or "when Claude finishes a task, send me a notification."
 
-## How Hooks Work
+You don't need to know much about them to benefit from them. The two hooks that come with this setup (auto-format and task notifications) just work out of the box after running `setup.sh`.
 
-Hooks are defined in `~/.claude/settings.json` (user-level) or
-`.claude/settings.json` (project-level). Claude Code runs them as subprocesses
-at the specified lifecycle points.
+This guide is for when you want to go further and build your own.
+
+---
+
+## How It Works
+
+Hooks live in a `settings.json` file in your Claude config folder. When something happens — Claude edits a file, runs a command, finishes a task — Claude Code checks if any hooks match and runs them.
 
 ```json
 {
@@ -28,40 +30,45 @@ at the specified lifecycle points.
 }
 ```
 
-## Hook Events
+This says: "After Claude edits or writes a file, run `post-edit.sh`. When Claude finishes a task, run `notify.sh`."
 
-| Event | Fires When | Common Uses |
+---
+
+## When Hooks Can Fire
+
+| Event | When it fires | Good for |
 |---|---|---|
-| `PreToolUse` | Before Claude calls a tool | Validation, logging, blocking dangerous ops |
-| `PostToolUse` | After a tool call completes | Auto-format, lint, update indexes |
-| `Notification` | Claude sends a user notification | Forward to Slack, mobile push |
-| `Stop` | Main agent turn finishes | Desktop notification, logging, CI trigger |
+| `PreToolUse` | *Before* Claude runs a tool | Blocking dangerous commands, validating inputs |
+| `PostToolUse` | *After* Claude runs a tool | Auto-formatting, updating indexes, linting |
+| `Notification` | When Claude sends you a message | Forwarding to Slack, sending a push notification |
+| `Stop` | When Claude finishes its turn | Desktop notification, logging, triggering CI |
 
-## Matchers
+---
 
-The `matcher` field filters which tool calls trigger the hook. It uses
-permission-rule syntax.
+## Matching the Right Events
 
-**Tool name matching:**
+The `matcher` field lets you be specific about which tool calls trigger your hook. You can match broadly or precisely:
+
 ```json
-"matcher": "Edit"           // only Edit tool
-"matcher": "Edit|Write"     // Edit or Write
-"matcher": "Bash"           // any Bash call
-"matcher": "Bash(rm *)"     // only Bash calls starting with "rm "
+"matcher": "Edit"           // fires only when Claude edits a file
+"matcher": "Edit|Write"     // fires for edits OR new file writes
+"matcher": "Bash"           // fires for any shell command Claude runs
+"matcher": "Bash(rm *)"     // fires only for shell commands that start with "rm "
 ```
 
-**MCP tool matching:**
+You can also match MCP plugin actions:
 ```json
-"matcher": "mcp__playwright__*"      // any Playwright MCP tool
-"matcher": "mcp__github__create_*"   // GitHub create operations only
+"matcher": "mcp__playwright__*"      // any Playwright action
+"matcher": "mcp__github__create_*"   // only GitHub "create" actions
 ```
 
-**No matcher** (omit the field) matches all tool calls for that event.
+Leave out the `matcher` entirely to catch everything for that event type.
 
-## The `if` Field (Conditional Hooks)
+---
 
-Narrow hook execution further with the `if` field using the same syntax as
-permission rules:
+## Extra Filtering with `if`
+
+Sometimes you need the matcher to be even more specific. The `if` field adds a second check:
 
 ```json
 {
@@ -71,39 +78,50 @@ permission rules:
 }
 ```
 
-## Environment Variables
+This only triggers for Bash commands that start with `git push`.
 
-Claude Code injects context into hook processes:
+---
 
-| Variable | Set For | Value |
+## What Your Hook Script Can Read
+
+Claude passes context to your hook script through environment variables:
+
+| Variable | Available when | What's in it |
 |---|---|---|
-| `CLAUDE_TOOL_NAME` | All hooks | Tool that triggered the hook (`Edit`, `Bash`, etc.) |
-| `CLAUDE_TOOL_INPUT_FILE_PATH` | Edit/Write | Absolute path of the modified file |
-| `CLAUDE_TOOL_INPUT_COMMAND` | Bash | The command string being run |
-| `CLAUDE_NOTIFICATION_MESSAGE` | Notification/Stop | Message from Claude |
+| `CLAUDE_TOOL_NAME` | Always | Which tool fired the hook (`Edit`, `Bash`, etc.) |
+| `CLAUDE_TOOL_INPUT_FILE_PATH` | Edit / Write hooks | The full path of the file Claude just touched |
+| `CLAUDE_TOOL_INPUT_COMMAND` | Bash hooks | The exact command Claude is about to run or just ran |
+| `CLAUDE_NOTIFICATION_MESSAGE` | Notification / Stop hooks | The message Claude is surfacing to you |
 
-## Exit Codes
+---
 
-| Code | Meaning |
+## What Your Script Should Return
+
+Your script's exit code tells Claude what to do next:
+
+| Exit code | What it means |
 |---|---|
-| `0` | Success — Claude continues normally |
-| `1` | Error — logged but Claude continues |
-| `2` | **Block** (PreToolUse only) — Claude skips the tool call |
+| `0` | All good — Claude continues normally |
+| `1` | Something went wrong — Claude logs it and continues anyway |
+| `2` | **Block this action** (PreToolUse only) — Claude skips the tool call entirely |
 
-## Examples
+Exit code `2` is how you prevent Claude from doing something. It only works on `PreToolUse` hooks — you can't stop something that's already happened.
 
-### Auto-format after file edits
+---
 
-Already included at `scripts/post-edit.sh`. Runs Prettier, Ruff/Black, gofmt,
-or rustfmt depending on the file extension. No-ops silently if no formatter is
-found.
+## Example Hooks
 
-### Desktop notification on task completion
+### Auto-format files after Claude edits them
 
-Already included at `scripts/notify.sh`. Uses `osascript` on macOS and
-`notify-send` on Linux.
+This one's already included at `scripts/post-edit.sh`. It checks the file extension and runs the right formatter — Prettier for JS/TS, Ruff for Python, gofmt for Go, rustfmt for Rust. If none of those are installed, it does nothing.
 
-### Block accidental `git push --force` to main
+### Desktop notification when Claude finishes
+
+Also already included at `scripts/notify.sh`. It pops up a system notification when Claude is done with a task — so you can step away from your desk without having to check back constantly.
+
+### Block accidental force-pushes
+
+This one prevents Claude from ever running `git push --force`, which can overwrite your teammates' work:
 
 ```bash
 # ~/.claude/scripts/block-force-push.sh
@@ -116,6 +134,7 @@ fi
 exit 0
 ```
 
+Then add it to your `settings.json`:
 ```json
 {
   "hooks": {
@@ -129,7 +148,9 @@ exit 0
 }
 ```
 
-### Log every file Claude touches
+### Keep a log of every file Claude touches
+
+Useful if you want to review what changed during a long session:
 
 ```bash
 # ~/.claude/scripts/audit-log.sh
@@ -139,7 +160,9 @@ echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) EDIT ${CLAUDE_TOOL_INPUT_FILE_PATH:-}" \
 exit 0
 ```
 
-## Installing the Defaults
+---
+
+## Getting Started (Already Done If You Ran setup.sh)
 
 `setup.sh` copies `post-edit.sh` and `notify.sh` to `~/.claude/scripts/`,
 makes them executable, and installs `~/.claude/settings.json` automatically
@@ -149,6 +172,8 @@ If `~/.claude/settings.json` is already present, `setup.sh` skips replacing
 it to preserve your existing Claude Code settings. In that case, manually
 merge the hook entries from `config/settings.json` into your existing file,
 then restart Claude Code.
+
+---
 
 ## Further Reading
 

--- a/docs/hooks-guide.md
+++ b/docs/hooks-guide.md
@@ -141,15 +141,14 @@ exit 0
 
 ## Installing the Defaults
 
-`setup.sh` copies `post-edit.sh` and `notify.sh` to `~/.claude/scripts/` and
-makes them executable. Copy `config/settings.json` to `~/.claude/settings.json`
-to activate the hooks:
+`setup.sh` copies `post-edit.sh` and `notify.sh` to `~/.claude/scripts/`,
+makes them executable, and installs `~/.claude/settings.json` automatically
+if it does not already exist.
 
-```bash
-cp config/settings.json ~/.claude/settings.json
-```
-
-Restart Claude Code after editing `settings.json`.
+If `~/.claude/settings.json` is already present, `setup.sh` skips replacing
+it to preserve your existing Claude Code settings. In that case, manually
+merge the hook entries from `config/settings.json` into your existing file,
+then restart Claude Code.
 
 ## Further Reading
 

--- a/docs/hooks-guide.md
+++ b/docs/hooks-guide.md
@@ -1,0 +1,157 @@
+# Hooks Guide
+
+Claude Code hooks let you run shell commands automatically in response to
+Claude's actions. Use them to auto-format files after edits, send notifications
+when tasks complete, enforce policies, or integrate with external tools.
+
+## How Hooks Work
+
+Hooks are defined in `~/.claude/settings.json` (user-level) or
+`.claude/settings.json` (project-level). Claude Code runs them as subprocesses
+at the specified lifecycle points.
+
+```json
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [{ "type": "command", "command": "~/.claude/scripts/post-edit.sh" }]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [{ "type": "command", "command": "~/.claude/scripts/notify.sh" }]
+      }
+    ]
+  }
+}
+```
+
+## Hook Events
+
+| Event | Fires When | Common Uses |
+|---|---|---|
+| `PreToolUse` | Before Claude calls a tool | Validation, logging, blocking dangerous ops |
+| `PostToolUse` | After a tool call completes | Auto-format, lint, update indexes |
+| `Notification` | Claude sends a user notification | Forward to Slack, mobile push |
+| `Stop` | Main agent turn finishes | Desktop notification, logging, CI trigger |
+
+## Matchers
+
+The `matcher` field filters which tool calls trigger the hook. It uses
+permission-rule syntax.
+
+**Tool name matching:**
+```json
+"matcher": "Edit"           // only Edit tool
+"matcher": "Edit|Write"     // Edit or Write
+"matcher": "Bash"           // any Bash call
+"matcher": "Bash(rm *)"     // only Bash calls starting with "rm "
+```
+
+**MCP tool matching:**
+```json
+"matcher": "mcp__playwright__*"      // any Playwright MCP tool
+"matcher": "mcp__github__create_*"   // GitHub create operations only
+```
+
+**No matcher** (omit the field) matches all tool calls for that event.
+
+## The `if` Field (Conditional Hooks)
+
+Narrow hook execution further with the `if` field using the same syntax as
+permission rules:
+
+```json
+{
+  "matcher": "Bash",
+  "if": "Bash(git push*)",
+  "hooks": [{ "type": "command", "command": "~/.claude/scripts/pre-push-check.sh" }]
+}
+```
+
+## Environment Variables
+
+Claude Code injects context into hook processes:
+
+| Variable | Set For | Value |
+|---|---|---|
+| `CLAUDE_TOOL_NAME` | All hooks | Tool that triggered the hook (`Edit`, `Bash`, etc.) |
+| `CLAUDE_TOOL_INPUT_FILE_PATH` | Edit/Write | Absolute path of the modified file |
+| `CLAUDE_TOOL_INPUT_COMMAND` | Bash | The command string being run |
+| `CLAUDE_NOTIFICATION_MESSAGE` | Notification/Stop | Message from Claude |
+
+## Exit Codes
+
+| Code | Meaning |
+|---|---|
+| `0` | Success — Claude continues normally |
+| `1` | Error — logged but Claude continues |
+| `2` | **Block** (PreToolUse only) — Claude skips the tool call |
+
+## Examples
+
+### Auto-format after file edits
+
+Already included at `scripts/post-edit.sh`. Runs Prettier, Ruff/Black, gofmt,
+or rustfmt depending on the file extension. No-ops silently if no formatter is
+found.
+
+### Desktop notification on task completion
+
+Already included at `scripts/notify.sh`. Uses `osascript` on macOS and
+`notify-send` on Linux.
+
+### Block accidental `git push --force` to main
+
+```bash
+# ~/.claude/scripts/block-force-push.sh
+#!/bin/bash
+CMD="${CLAUDE_TOOL_INPUT_COMMAND:-}"
+if [[ "$CMD" == *"push"*"--force"* ]] || [[ "$CMD" == *"push"*"-f"* ]]; then
+  echo "Blocked: force push is not allowed" >&2
+  exit 2
+fi
+exit 0
+```
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash(git push*)",
+        "hooks": [{ "type": "command", "command": "~/.claude/scripts/block-force-push.sh" }]
+      }
+    ]
+  }
+}
+```
+
+### Log every file Claude touches
+
+```bash
+# ~/.claude/scripts/audit-log.sh
+#!/bin/bash
+echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) EDIT ${CLAUDE_TOOL_INPUT_FILE_PATH:-}" \
+  >> ~/.claude/audit.log
+exit 0
+```
+
+## Installing the Defaults
+
+`setup.sh` copies `post-edit.sh` and `notify.sh` to `~/.claude/scripts/` and
+makes them executable. Copy `config/settings.json` to `~/.claude/settings.json`
+to activate the hooks:
+
+```bash
+cp config/settings.json ~/.claude/settings.json
+```
+
+Restart Claude Code after editing `settings.json`.
+
+## Further Reading
+
+- [Claude Code Hooks Reference](https://docs.anthropic.com/claude-code/hooks)
+- [Permission Rule Syntax](https://docs.anthropic.com/claude-code/settings#permissions)

--- a/scripts/notify.sh
+++ b/scripts/notify.sh
@@ -5,7 +5,11 @@ TITLE="Claude Code"
 MESSAGE="${CLAUDE_NOTIFICATION_MESSAGE:-Task complete}"
 
 if [[ "$OSTYPE" == "darwin"* ]]; then
-  osascript -e "display notification \"$MESSAGE\" with title \"$TITLE\"" &>/dev/null
+  osascript - "$MESSAGE" "$TITLE" &>/dev/null <<'APPLESCRIPT'
+on run argv
+  display notification (item 1 of argv) with title (item 2 of argv)
+end run
+APPLESCRIPT
 elif command -v notify-send &>/dev/null; then
   notify-send "$TITLE" "$MESSAGE" &>/dev/null
 fi

--- a/scripts/notify.sh
+++ b/scripts/notify.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Sends a desktop notification when Claude finishes a task (Stop hook).
+
+TITLE="Claude Code"
+MESSAGE="${CLAUDE_NOTIFICATION_MESSAGE:-Task complete}"
+
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  osascript -e "display notification \"$MESSAGE\" with title \"$TITLE\"" &>/dev/null
+elif command -v notify-send &>/dev/null; then
+  notify-send "$TITLE" "$MESSAGE" &>/dev/null
+fi
+
+exit 0

--- a/scripts/post-edit.sh
+++ b/scripts/post-edit.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# Runs after Claude edits or writes a file.
+# Reads the modified file path from CLAUDE_TOOL_INPUT_FILE_PATH env var.
+# Silently skips if no formatter is available for the file type.
+
+FILE="${CLAUDE_TOOL_INPUT_FILE_PATH:-}"
+
+if [ -z "$FILE" ] || [ ! -f "$FILE" ]; then
+  exit 0
+fi
+
+EXT="${FILE##*.}"
+
+case "$EXT" in
+  js|jsx|ts|tsx|json|css|scss|html|md|yaml|yml)
+    if command -v prettier &>/dev/null; then
+      prettier --write "$FILE" &>/dev/null
+    fi
+    ;;
+  py)
+    if command -v ruff &>/dev/null; then
+      ruff format "$FILE" &>/dev/null
+    elif command -v black &>/dev/null; then
+      black --quiet "$FILE" &>/dev/null
+    fi
+    ;;
+  go)
+    if command -v gofmt &>/dev/null; then
+      gofmt -w "$FILE" &>/dev/null
+    fi
+    ;;
+  rs)
+    if command -v rustfmt &>/dev/null; then
+      rustfmt "$FILE" &>/dev/null
+    fi
+    ;;
+esac
+
+exit 0

--- a/setup.sh
+++ b/setup.sh
@@ -762,34 +762,72 @@ setup_mcp_servers() {
     echo ""
 }
 
+# Install settings.json (hooks + permissions) and scoped rules
+setup_hooks_and_rules() {
+    echo -e "${BLUE}🪝 Setting up hooks and scoped rules...${NC}"
+
+    local settings_src="$CLAUDE_HELPERS_DIR/$CONFIG_DIR/settings.json"
+    local settings_dst="$CLAUDE_DIR/settings.json"
+
+    # Install settings.json
+    if [ -f "$settings_src" ]; then
+        if [ -f "$settings_dst" ]; then
+            echo -e "${YELLOW}⚠️  $settings_dst already exists — skipping to preserve your customizations${NC}"
+            echo -e "${BLUE}ℹ️  Reference copy available at: $settings_src${NC}"
+        else
+            cp "$settings_src" "$settings_dst"
+            echo -e "${GREEN}✅ Installed hooks config to $settings_dst${NC}"
+        fi
+    fi
+
+    # Install scoped rules
+    local rules_src="$CLAUDE_HELPERS_DIR/.claude/rules"
+    local rules_dst="$CLAUDE_DIR/rules"
+
+    if [ -d "$rules_src" ]; then
+        mkdir -p "$rules_dst"
+        cp -n "$rules_src/"*.md "$rules_dst/" 2>/dev/null
+        echo -e "${GREEN}✅ Installed scoped rules to $rules_dst${NC}"
+    fi
+
+    # Make hook scripts executable
+    chmod +x "$SCRIPTS_INSTALL_DIR/post-edit.sh" 2>/dev/null
+    chmod +x "$SCRIPTS_INSTALL_DIR/notify.sh" 2>/dev/null
+
+    echo ""
+}
+
 # Main setup flow
 main() {
     # Step 1: Detect platform
     detect_platform
-    
+
     # Step 2: Install Homebrew on macOS if needed
     if [[ "$OS" == "macOS" ]]; then
         install_homebrew
     fi
-    
+
     # Step 3: Install core scripts
     if ! install_core_scripts; then
         echo -e "${RED}❌ Failed to install core scripts${NC}"
         exit 1
     fi
-    
+
     # Step 4: Setup shell aliases
     setup_shell_aliases
-    
+
     # Step 5: Create/update global CLAUDE.md
     setup_global_claude_md
-    
+
     # Step 6: Setup MCP servers
     setup_mcp_servers
-    
-    # Step 7: Check and offer to install optional tools
+
+    # Step 7: Install hooks config and scoped rules
+    setup_hooks_and_rules
+
+    # Step 8: Check and offer to install optional tools
     check_optional_tools
-    
+
     # Final instructions
     echo -e "${GREEN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
     echo -e "${GREEN}✨ Setup Complete!${NC}"


### PR DESCRIPTION
- Add config/settings.json with PostToolUse/Stop hooks and curated permissions allowlist
- Add scripts/post-edit.sh: auto-formats files after edits (Prettier, Ruff, gofmt, rustfmt)
- Add scripts/notify.sh: desktop notification on task completion (macOS + Linux)
- Add .claude/rules/ scoped CLAUDE.md rules for TypeScript, Python, and testing conventions
- Add config/mcp.json: new servers — filesystem, github, sequential-thinking (lazy-loaded)
- Add commands/ultrareview.md: deep multi-agent branch diff review
- Add commands/autofix-pr.md: automated CI failure and review feedback remediation
- Add docs/hooks-guide.md: full hooks reference with examples and env var table
- Update README with hooks, scoped rules, MCP lazy-loading, Claude 4.x model table,
  auto mode, plan mode, routines, desktop app, and VS Code extension sections
- Update CLAUDE_USER.md and CLAUDE_PROJECT.md with Claude 4.x model references and
  expanded MCP server list
- Update setup.sh to install settings.json and scoped rules via new setup_hooks_and_rules()

https://claude.ai/code/session_01H8UgMcY53yqiV8HFrCmCL6