### PR TITLE
Add Not Human Search and AI Dev Jobs to MCP Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,8 @@ MCP plugins extend what Claude can do. The great thing is they only "wake up" wh
 | **Filesystem** | Structured access to your files (optional, manual setup) |
 | **GitHub** | Read and write issues, PRs, and code on GitHub (needs a token) |
 | **Sequential Thinking** | Step-by-step structured reasoning for complex problems |
+| **[Not Human Search](https://nothumansearch.ai/mcp)** | Search 8,000+ MCP servers and agent-readable sites; includes `verify_mcp` live probe. Install: `claude mcp add --transport http nothumansearch https://nothumansearch.ai/mcp` |
+| **[AI Dev Jobs](https://aidevboard.com/mcp)** | Query 8,400+ AI/ML engineering jobs. Install: `claude mcp add --transport http aidevboard https://aidevboard.com/mcp` |
 
 `setup.sh` handles Playwright and Context7 automatically. The others need a quick manual setup — copy `config/mcp.json` to `~/.claude/mcp.json` and fill in your paths and tokens (there are notes in the file explaining each one).
 


### PR DESCRIPTION
Adds two remote MCP servers to the **MCP Plugins** table — both one-liner installable, no auth, remotely-hosted so no local setup or config.json edit needed.

**Not Human Search** (`https://nothumansearch.ai/mcp`)
- 8 tools for discovering agent-readable services: search_agents, verify_mcp (live JSON-RPC probe), get_site_details, get_top_sites, list_categories, get_stats, submit_site, register_monitor
- Useful alongside Context7 — Context7 gets you up-to-date docs for known libraries, NHS helps Claude discover tools/libraries it doesn't already know

**AI Dev Jobs** (`https://aidevboard.com/mcp`)
- 4 tools: search_jobs, get_job, list_companies, get_stats
- 8,400+ AI/ML engineering jobs across 580 ATS sources; useful for anyone using Claude Code to research hiring or find work

Both are in the official MCP registry (`ai.nothumansearch/search`, `com.aidevboard/jobs`), MIT-licensed, production-ready.