### PR TITLE
Add Bring Your AI to MCP Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ MCP plugins extend what Claude can do. The great thing is they only "wake up" wh
 | **Filesystem** | Structured access to your files (optional, manual setup) |
 | **GitHub** | Read and write issues, PRs, and code on GitHub (needs a token) |
 | **Sequential Thinking** | Step-by-step structured reasoning for complex problems |
+| **[Bring Your AI](https://bringyour.ai)** | Migrate Claude Code context (rules, skills, hooks, MCP config) to Codex and other harnesses — remote MCP at bringyour.ai/mcp, no data retained |
 
 `setup.sh` handles Playwright and Context7 automatically. The others need a quick manual setup — copy `config/mcp.json` to `~/.claude/mcp.json` and fill in your paths and tokens (there are notes in the file explaining each one).
 


### PR DESCRIPTION
Adds [Bring Your AI](https://bringyour.ai) to the MCP Plugins table.

BYA is a local-first migration tool specifically for Claude Code users — it packages your operating context (CLAUDE.md rules, skills, hooks, MCP config, validation notes) for installation into Codex and other agent harnesses. The remote MCP server at `bringyour.ai/mcp` is no-data: it returns previews and install commands without receiving any harness files or project content.

This is a natural addition to the MCP Plugins section for Claude Code users who want to carry their Claude setup into other environments. Listed in the official MCP registry as `ai.bringyour/bringyour`.